### PR TITLE
fix(security): restrict GET /api/users/{id} to admins

### DIFF
--- a/src/main/java/ch/ethy/recipes/user/UserController.java
+++ b/src/main/java/ch/ethy/recipes/user/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
   }
 
   @GetMapping("{id}")
-  @RolesAllowed("USER")
+  @RolesAllowed("ADMIN")
   public UserDto getUser(@PathVariable long id) {
     return userService
         .findUser(id)

--- a/src/test/java/ch/ethy/recipes/user/UserControllerSecurityTest.java
+++ b/src/test/java/ch/ethy/recipes/user/UserControllerSecurityTest.java
@@ -1,0 +1,96 @@
+package ch.ethy.recipes.user;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.ethy.recipes.security.JwtService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+class UserControllerSecurityTest {
+
+  @TestConfiguration
+  @EnableMethodSecurity(jsr250Enabled = true)
+  static class SecurityTestConfig {
+    // Mirror the parts of the production SecurityConfig that determine the
+    // status code: anonymous is disabled and unauthenticated requests are
+    // answered with 401 (not the Spring default of 403 via anonymous + access
+    // denied).
+    @Bean
+    SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+      return http.csrf(AbstractHttpConfigurer::disable)
+          .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+          .anonymous(AbstractHttpConfigurer::disable)
+          .exceptionHandling(
+              eh -> eh.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+          .build();
+    }
+  }
+
+  @Autowired private MockMvc mockMvc;
+  @MockitoBean private UserService userService;
+
+  // JWTFilter is pulled into the @WebMvcTest slice as a servlet filter and
+  // declares a JwtService dependency. We use @WithMockUser to set the security
+  // context directly, so the real JWT path is not exercised here — mocking
+  // the dependency keeps the slice context wireable.
+  @MockitoBean private JwtService jwtService;
+
+  @BeforeEach
+  void stubExistingUser() {
+    when(userService.findUser(1L))
+        .thenReturn(Optional.of(new UserDto(1L, "alice", "alice@example.com")));
+  }
+
+  @Test
+  void getUserByIdRejectsUnauthenticated() throws Exception {
+    mockMvc.perform(get("/api/users/1")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  void getUserByIdRejectsNonAdmin() throws Exception {
+    mockMvc.perform(get("/api/users/1")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void getUserByIdAllowsAdmin() throws Exception {
+    mockMvc.perform(get("/api/users/1")).andExpect(status().isOk());
+  }
+
+  @Test
+  void getAllUsersRejectsUnauthenticated() throws Exception {
+    mockMvc.perform(get("/api/users")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  void getAllUsersRejectsNonAdmin() throws Exception {
+    mockMvc.perform(get("/api/users")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void getAllUsersAllowsAdmin() throws Exception {
+    when(userService.getAllUsers()).thenReturn(List.of());
+    mockMvc.perform(get("/api/users")).andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
Closes #146.

The endpoint was annotated \`@RolesAllowed(\"USER\")\`, so any authenticated user could fetch any other user's record by id — a classic IDOR. The project has no use case for non-admins reading other users' details, so the simplest fix is to lock the lookup to ADMIN; an ownership-guard variant can be added later if a "view your own profile" feature actually arrives.

The test introduces the project's first \`@WebMvcTest\` slice. \`JWTFilter\` is pulled into the slice as a servlet filter, so its \`JwtService\` dependency is stubbed with \`@MockitoBean\` to keep the context wireable; \`@WithMockUser\` supplies the security context directly. Notes on the Boot 4 quirks I hit while wiring this up are saved as a reference memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)