### PR TITLE
fix(security): prod-safe JPA defaults via dev profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A recipe management web application with a Spring Boot 4 (Java 21) backend and A
 
 ### Backend (Maven)
 - `./mvnw spring-boot:run` — run the Spring Boot app
-- `SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run` — run locally with the `dev` profile (Hibernate `ddl-auto: update`). The default profile uses prod-safe values.
+- `SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run` — run locally with the `dev` profile (Hibernate `ddl-auto: update`, SQL logging on). The default profile uses prod-safe values.
 - `./mvnw clean package` — full build (includes frontend build, lint, format check, and tests via frontend-maven-plugin)
 - `./mvnw test` — run backend tests + frontend lint/format/tests
 - `./mvnw spotless:apply` — auto-format Java code (Google Java Format)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ A recipe management web application with a Spring Boot 4 (Java 21) backend and A
 
 ### Backend (Maven)
 - `./mvnw spring-boot:run` — run the Spring Boot app
+- `SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run` — run locally with the `dev` profile (Hibernate `ddl-auto: update`). The default profile uses prod-safe values.
 - `./mvnw clean package` — full build (includes frontend build, lint, format check, and tests via frontend-maven-plugin)
 - `./mvnw test` — run backend tests + frontend lint/format/tests
 - `./mvnw spotless:apply` — auto-format Java code (Google Java Format)

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,4 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -2,3 +2,4 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    show-sql: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
   web:
     resources:
       static-locations: "classpath:/public/,classpath:/static/browser/"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
       '[db_password]': ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
   web:
     resources:


### PR DESCRIPTION
Closes #147.
Closes #156.

`application.yaml` previously ran with `ddl-auto: update` and `show-sql: true`, which respectively let Hibernate silently alter the production schema and dumped SQL (including parameter values) into the prod log stream. Both knobs are now off in the default profile.

Local development still benefits from both, so they're moved into a new `application-dev.yaml`. Activate it via `SPRING_PROFILES_ACTIVE=dev` (documented in CLAUDE.md). Forgetting to set the profile in prod is harmless — the default is the safe one.

`ddl-auto: validate` (rather than `none`) is the chosen default so prod fails fast on entity↔schema drift instead of starting up against a mismatched schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)