### PR TITLE
refactor(test): mock JwtService in JWTFilter and AuthService tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
     <google-java-format.version>1.31.0</google-java-format.version>
     <spotless.version>3.5.1</spotless.version>
     <jjwt.version>0.13.0</jjwt.version>
+    <!-- Empty default so other plugins (e.g. jacoco) can append to argLine
+         via late-binding @{argLine} in the surefire config below. -->
+    <argLine></argLine>
   </properties>
   <dependencies>
     <dependency>
@@ -105,6 +108,30 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>resolve-mockito-agent</id>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- @{argLine} late-binds so other plugins (e.g. jacoco) can append flags.
+               ${org.mockito:mockito-core:jar} is populated by
+               maven-dependency-plugin:properties in the initialize phase; running
+               `mvn surefire:test` directly will skip that phase, leaving the
+               placeholder unexpanded. Use `mvn test` or higher. -->
+          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.github.eirslett</groupId>

--- a/src/test/java/ch/ethy/recipes/security/AuthServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/security/AuthServiceTest.java
@@ -3,16 +3,25 @@ package ch.ethy.recipes.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import ch.ethy.recipes.user.Role;
 import ch.ethy.recipes.user.UserRepository;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -21,43 +30,61 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
   @Mock private AuthenticationManager authenticationManager;
+  @Mock private JwtService jwtService;
   @Mock private PasswordEncoder passwordEncoder;
   @Mock private UserRepository userRepository;
 
-  private static final String TEST_ENCODED_KEY =
-      "sPYf4F91EbSV6mfc+ZoqZhVuZih8mTiyx1jjPCq8qeuBaCnOlpq8gm3XwFPFo8Sj";
-  private final JwtService jwtService = new JwtService(TEST_ENCODED_KEY);
+  @InjectMocks private AuthService authService;
+
+  private Logger authServiceLogger;
+  private ListAppender<ILoggingEvent> logAppender;
+
+  @BeforeEach
+  void captureAuthServiceLogs() {
+    authServiceLogger = (Logger) LoggerFactory.getLogger(AuthService.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    authServiceLogger.addAppender(logAppender);
+    authServiceLogger.setAdditive(false);
+  }
+
+  @AfterEach
+  void restoreAuthServiceLogs() {
+    authServiceLogger.detachAppender(logAppender);
+    authServiceLogger.setAdditive(true);
+  }
 
   @Test
-  void loginProducesTokenCarryingAuthenticatedUsernameAndRoles() {
+  void loginAsksJwtServiceToTokenizeAuthenticatedUsernameAndRoles() {
     var principal =
         new org.springframework.security.core.userdetails.User(
             "alice", "pw", Set.of(Role.USER, Role.ADMIN));
     Authentication authenticated =
         new UsernamePasswordAuthenticationToken(principal, "pw", principal.getAuthorities());
     when(authenticationManager.authenticate(any())).thenReturn(authenticated);
-
-    AuthService authService =
-        new AuthService(authenticationManager, jwtService, passwordEncoder, userRepository);
+    when(jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN))).thenReturn("token-xyz");
 
     String token = authService.login(new LoginCredentials("alice", "pw"));
 
-    JwtService.TokenData parsed = jwtService.parseToken(token);
-    assertEquals("alice", parsed.username());
-    assertEquals(Set.of(Role.USER, Role.ADMIN), parsed.roles());
+    assertEquals("token-xyz", token);
   }
 
   @Test
-  void loginThrowsWhenPrincipalIsNotAUserDetailsUser() {
+  void loginThrowsAndLogsPrincipalClassWhenPrincipalIsNotAUserDetailsUser() {
     Authentication authenticated =
         new UsernamePasswordAuthenticationToken("not-a-user-object", "pw", Set.of());
     when(authenticationManager.authenticate(any())).thenReturn(authenticated);
 
-    AuthService authService =
-        new AuthService(authenticationManager, jwtService, passwordEncoder, userRepository);
-
     assertThrows(
         IllegalStateException.class, () -> authService.login(new LoginCredentials("alice", "pw")));
+
+    assertEquals(1, logAppender.list.size());
+    ILoggingEvent logged = logAppender.list.get(0);
+    assertEquals(Level.ERROR, logged.getLevel());
+    assertTrue(
+        logged.getFormattedMessage().contains(String.class.getName()),
+        "Diagnostic log should name the unexpected principal class for operators: "
+            + logged.getFormattedMessage());
   }
 
   @Test
@@ -66,9 +93,6 @@ class AuthServiceTest {
     Authentication authenticated =
         new UsernamePasswordAuthenticationToken(sensitivePrincipal, "pw", Set.of());
     when(authenticationManager.authenticate(any())).thenReturn(authenticated);
-
-    AuthService authService =
-        new AuthService(authenticationManager, jwtService, passwordEncoder, userRepository);
 
     IllegalStateException thrown =
         assertThrows(

--- a/src/test/java/ch/ethy/recipes/security/JWTFilterTest.java
+++ b/src/test/java/ch/ethy/recipes/security/JWTFilterTest.java
@@ -4,11 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import ch.ethy.recipes.user.Role;
+import io.jsonwebtoken.MalformedJwtException;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -16,11 +22,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
+@ExtendWith(MockitoExtension.class)
 class JWTFilterTest {
-  private static final String TEST_ENCODED_KEY =
-      "sPYf4F91EbSV6mfc+ZoqZhVuZih8mTiyx1jjPCq8qeuBaCnOlpq8gm3XwFPFo8Sj";
-  private final JwtService jwtService = new JwtService(TEST_ENCODED_KEY);
-  private final JWTFilter filter = new JWTFilter(jwtService);
+  @Mock private JwtService jwtService;
+  @InjectMocks private JWTFilter filter;
 
   @AfterEach
   void clearSecurityContext() {
@@ -29,9 +34,10 @@ class JWTFilterTest {
 
   @Test
   void populatesAuthoritiesFromTokenRoles() throws Exception {
-    String token = jwtService.generateToken("alice", Set.of(Role.ADMIN));
+    when(jwtService.parseToken("opaque-token"))
+        .thenReturn(new JwtService.TokenData("alice", Set.of(Role.ADMIN)));
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.addHeader("Authorization", "Bearer " + token);
+    request.addHeader("Authorization", "Bearer opaque-token");
     MockHttpServletResponse response = new MockHttpServletResponse();
     MockFilterChain chain = new MockFilterChain();
 
@@ -56,6 +62,8 @@ class JWTFilterTest {
 
   @Test
   void respondsUnauthorizedOnInvalidSignature() throws Exception {
+    when(jwtService.parseToken("not-a-real-token"))
+        .thenThrow(new MalformedJwtException("bad signature"));
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("Authorization", "Bearer not-a-real-token");
     MockHttpServletResponse response = new MockHttpServletResponse();
@@ -69,6 +77,8 @@ class JWTFilterTest {
 
   @Test
   void doesNotContinueFilterChainAfterInvalidTokenError() throws Exception {
+    when(jwtService.parseToken("not-a-real-token"))
+        .thenThrow(new MalformedJwtException("bad signature"));
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("Authorization", "Bearer not-a-real-token");
     MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
## Summary
- `JWTFilterTest` and `AuthServiceTest` now mock `JwtService` instead of instantiating a real one with a duplicated base64 test key — keeps the unit-under-test cleanly separated from its collaborator and decouples them from `JwtService`'s constructor validation.
- Wired Mockito as a `-javaagent` (via `maven-dependency-plugin:properties` exposing `${org.mockito:mockito-core:jar}`) so the self-attach deprecation warning no longer fires when the new mocks need the inline mock maker.
- `AuthServiceTest`'s negative-path tests now capture the diagnostic ERROR log via a Logback `ListAppender` (`additive=false`) — no more noise in test output, plus an assertion that the log line names the unexpected principal class for operators.

`JwtServiceTest` still uses a real `JwtService` — that's where its constructor/parse behaviour belongs.

Closes #162

## Test plan
- [x] `./mvnw test` passes (26 backend tests + frontend)
- [x] No Mockito self-attach warning in surefire output
- [x] No stray `ERROR ch.ethy.recipes.security.AuthService` lines in test output