### PR TITLE
chore(agents): forbid posting retracted review findings

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -86,6 +86,10 @@ For each issue/suggestion, include:
 - Why it matters (or why you're flagging it)
 - A concrete suggestion or alternative when possible
 
+### Don't post findings you've retracted
+
+If a finding ends in "wait, actually…", "disregard the above", "never mind", "on reflection", or similar self-correction — **delete the entire finding before posting**. Mid-paragraph retractions are noise; the author has to read the dead reasoning to discover it doesn't apply. Your exploration belongs in your scratchpad; only conclusions you stand behind belong in the review. Same rule for titles: a heading like "*X can be replaced with Y… wait, actually it cannot — but…*" means the finding was rewritten mid-thought. Cut the retracted half and re-state the surviving claim cleanly.
+
 ### Labelling findings — do not use `#N`
 
 When you need to label or back-reference your own findings, **do not use `#<number>`** (e.g. `#1`, `#2`). GitHub auto-links those to issues in the repo, so "see issue #2 above" becomes a link to whatever random issue happens to have that number, which is confusing and noisy.
@@ -102,6 +106,7 @@ Before finalizing your review:
 - Is my tone neutral throughout? Re-read for phrasing that's either effusively polite/apologetic or dismissive/sarcastic, and adjust both directions toward plain, direct language.
 - Have I checked the code against project conventions in CLAUDE.md?
 - Did I miss any obvious categories (security, tests, edge cases)?
+- Scan for retraction phrases (`wait`, `actually`, `disregard`, `never mind`, `on reflection`). Any finding that ends in one is a half-thought that leaked through — delete it whole.
 
 ## When to Ask for Clarification
 

--- a/.claude/agents/web-security-reviewer.md
+++ b/.claude/agents/web-security-reviewer.md
@@ -71,6 +71,8 @@ For each finding, provide:
 - **Recommendation**: Specific code change or approach to fix it (with example when helpful)
 - **References**: OWASP/CWE links when relevant
 
+**Don't post findings you've retracted**: If a finding ends in "wait, actually…", "disregard the above", "never mind", "on reflection", or similar self-correction — **delete the entire finding before posting**. Mid-paragraph retractions are noise; the reader has to wade through dead reasoning to discover it doesn't apply. Your exploration belongs in your scratchpad; only conclusions you stand behind belong in the review. Same rule for headings: a title like "*X is broken — actually it's fine, but…*" means the finding was rewritten mid-thought. Cut the retracted half and re-state the surviving claim cleanly. Before submitting, scan for the phrases above — any finding that ends in one is a half-thought that leaked through. Delete it whole.
+
 **Labelling findings — do not use `#N`**: When you need to label or back-reference your own findings, do not use `#<number>` (e.g. `#1`, `#2`). GitHub auto-links those to issues in the repo, so a self-reference like "see #2 above" turns into a confusing link to whatever random issue happens to have that number. Use a bracketed label instead — e.g. `[C1]`, `[H2]`, `[M1]`, `[L1]` — and back-reference with the same label. Plain prose ("the hardcoded-key finding above") is also fine. `#<number>` is the correct syntax only when you actually mean to link an existing GitHub issue or PR.
 
 **Positive Observations**: Briefly note security-good practices you observed (encourages the developer)


### PR DESCRIPTION
## Summary
Both PR reviewers occasionally posted findings that ended in "wait, actually…", "disregard the above", or similar self-correction (e.g. PR #169 round-1 reviews). The retraction itself is noise — the author still has to read the dead reasoning to discover it doesn't apply.

Add an explicit rule to the Output Format section of both agents: delete the entire finding when it ends in a retraction; exploration belongs in the scratchpad, only conclusions worth standing behind belong in the review. Add a matching pre-submit checklist item to the `pr-code-reviewer`'s Self-Verification section that scans for the specific retraction phrases.