### PR TITLE
feat(security): return user roles alongside token on login

### DIFF
--- a/src/main/java/ch/ethy/recipes/security/AuthController.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
   }
 
   @PostMapping("/login")
-  public String login(@RequestBody LoginCredentials credentials) {
+  public LoginResponse login(@RequestBody LoginCredentials credentials) {
     try {
       return authService.login(credentials);
     } catch (AuthenticationException e) {

--- a/src/main/java/ch/ethy/recipes/security/AuthService.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
     this.userRepository = userRepository;
   }
 
-  public String login(LoginCredentials credentials) {
+  public LoginResponse login(LoginCredentials credentials) {
     UsernamePasswordAuthenticationToken authToken =
         new UsernamePasswordAuthenticationToken(
             credentials.usernameOrEmail(), credentials.password());
@@ -54,7 +54,8 @@ public class AuthService {
             .filter(Role.class::isInstance)
             .map(Role.class::cast)
             .collect(Collectors.toCollection(() -> EnumSet.noneOf(Role.class)));
-    return jwtService.generateToken(user.getUsername(), roles);
+    String token = jwtService.generateToken(user.getUsername(), roles);
+    return new LoginResponse(token, roles);
   }
 
   public void register(RegistrationDetails registrationDetails) {

--- a/src/main/java/ch/ethy/recipes/security/LoginResponse.java
+++ b/src/main/java/ch/ethy/recipes/security/LoginResponse.java
@@ -1,0 +1,14 @@
+package ch.ethy.recipes.security;
+
+import ch.ethy.recipes.user.Role;
+import java.util.Set;
+
+/**
+ * Returned to the client after a successful login.
+ *
+ * <p>The {@code roles} field is a convenience hint for UI rendering only (e.g., deciding which
+ * navigation items to show). It is <strong>not</strong> authoritative — every protected request is
+ * authorized server-side by re-parsing the signed JWT, so a tampered or stale client copy of the
+ * roles cannot grant access.
+ */
+public record LoginResponse(String token, Set<Role> roles) {}

--- a/src/test/java/ch/ethy/recipes/security/AuthServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/security/AuthServiceTest.java
@@ -64,9 +64,10 @@ class AuthServiceTest {
     when(authenticationManager.authenticate(any())).thenReturn(authenticated);
     when(jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN))).thenReturn("token-xyz");
 
-    String token = authService.login(new LoginCredentials("alice", "pw"));
+    LoginResponse response = authService.login(new LoginCredentials("alice", "pw"));
 
-    assertEquals("token-xyz", token);
+    assertEquals("token-xyz", response.token());
+    assertEquals(Set.of(Role.USER, Role.ADMIN), response.roles());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `AuthService.login` now returns `LoginResponse(token, roles)` instead of the bare token string, and `AuthController#login` serializes the new record.
- Completes the last slice of #85 — the role claim and token-sourced authorities already shipped on main; only the response contract was missing.

## Test plan
- [x] `./mvnw test` — backend + frontend
- [ ] After deploy, confirm `POST /api/auth/login` returns `{ "token": "...", "roles": ["USER"] }` and that existing clients still function.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)