### PR TITLE
refactor(security): pin Role wire formats with regression tests

### DIFF
--- a/src/main/java/ch/ethy/recipes/user/Role.java
+++ b/src/main/java/ch/ethy/recipes/user/Role.java
@@ -2,6 +2,23 @@ package ch.ethy.recipes.user;
 
 import org.springframework.security.core.GrantedAuthority;
 
+/**
+ * User roles, used in two distinct serialization contexts:
+ *
+ * <ul>
+ *   <li><strong>JWT wire format</strong> — the {@code roles} claim contains the bare enum {@link
+ *       #name()} (e.g. {@code "USER"}, {@code "ADMIN"}). The token is read back by matching these
+ *       names to enum constants.
+ *   <li><strong>Spring Security authority</strong> — {@link #getAuthority()} returns {@code "ROLE_"
+ *       + name()} (e.g. {@code "ROLE_ADMIN"}), the prefix Spring's {@code hasRole(...)} and
+ *       {@code @PreAuthorize("hasRole('ADMIN')")} expect.
+ * </ul>
+ *
+ * <p>Do not add a constant whose {@link #name()} starts with {@code ROLE_} — {@link
+ * #getAuthority()} would then yield {@code "ROLE_ROLE_…"} and silently fail authorization checks.
+ * Tests in {@code RoleTest} and {@code JwtServiceTest} pin these two wire formats so a rename or
+ * authority-format change breaks the build loudly.
+ */
 public enum Role implements GrantedAuthority {
   USER,
   ADMIN;

--- a/src/test/java/ch/ethy/recipes/security/JwtServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/security/JwtServiceTest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.crypto.SecretKey;
@@ -44,6 +45,24 @@ class JwtServiceTest {
     String token = jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN));
 
     assertEquals(Set.of(Role.USER, Role.ADMIN), jwtService.parseToken(token).roles());
+  }
+
+  @Test
+  void generateTokenSerializesRolesAsEnumNameStrings() {
+    // Pins the JWT wire format: the 'roles' claim is a JSON array of Role.name() strings
+    // (e.g. "USER", "ADMIN"), not getAuthority() values ("ROLE_USER", ...). A rename of a
+    // Role constant changes the token payload and must break this test loudly.
+    String token = jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN));
+
+    List<?> rolesClaim =
+        Jwts.parser()
+            .verifyWith(SIGNING_KEY)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get("roles", List.class);
+
+    assertEquals(Set.of("USER", "ADMIN"), new HashSet<>(rolesClaim));
   }
 
   @Test

--- a/src/test/java/ch/ethy/recipes/user/RoleTest.java
+++ b/src/test/java/ch/ethy/recipes/user/RoleTest.java
@@ -1,0 +1,39 @@
+package ch.ethy.recipes.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+class RoleTest {
+  @Test
+  void roleEnumNamesPinTheJwtWireFormat() {
+    // The strings written to / read from the JWT 'roles' claim are Role.name().
+    // Renaming an enum constant is a breaking change to the token payload — this test
+    // forces the rename to be intentional rather than silent.
+    assertEquals("USER", Role.USER.name());
+    assertEquals("ADMIN", Role.ADMIN.name());
+  }
+
+  @Test
+  void roleAuthoritiesUseSpringRolePrefix() {
+    // getAuthority() feeds Spring Security's hasRole(...) / @PreAuthorize("hasRole('ADMIN')"),
+    // which strip the "ROLE_" prefix. Drift here silently breaks authorization checks.
+    assertEquals("ROLE_USER", Role.USER.getAuthority());
+    assertEquals("ROLE_ADMIN", Role.ADMIN.getAuthority());
+  }
+
+  @Test
+  void noRoleNameStartsWithRolePrefix() {
+    // getAuthority() prepends "ROLE_" to name(). A constant named e.g. ROLE_OWNER would
+    // produce getAuthority() == "ROLE_ROLE_OWNER" and silently fail hasRole('OWNER') checks.
+    for (Role role : Role.values()) {
+      assertFalse(
+          role.name().startsWith("ROLE_"),
+          "Role."
+              + role.name()
+              + " — names starting with ROLE_ break getAuthority(); use bare"
+              + " name");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `RoleTest` pinning `Role.USER`/`Role.ADMIN` enum names and `getAuthority()` strings against literal expectations.
- Adds `JwtServiceTest#generateTokenSerializesRolesAsEnumNameStrings` pinning the on-wire JWT `roles` claim to the bare enum-name list.
- Documents the two serialization contracts on `Role` and calls out the "no `ROLE_`-prefixed names" invariant.

## Test plan
- [x] `./mvnw test` — full backend + frontend (37 backend tests, all green)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)