### PR TITLE
feat(security): refresh-token flow with bounded role revocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,4 +63,6 @@ A recipe management web application with a Spring Boot 4 (Java 21) backend and A
 - `DB_PASSWORD` — MySQL app user password
 - `FLYWAY_PASSWORD` — Flyway migration user password
 - `JWT_SECRET` — Base64-encoded HMAC-SHA256 signing key for JWTs (required; minimum 32 bytes / 256 bits, but generate with `openssl rand -base64 48` for headroom)
-- `JWT_TTL` — Access-token lifetime as an ISO-8601 duration (default `PT24H`, maximum `P30D`). Tokens are rejected on parse once expired or missing the `exp` claim.
+- `JWT_ACCESS_TTL` — Access-token lifetime as an ISO-8601 duration (default `PT15M`, maximum `P30D`). The access token is sent on every request and is rejected once expired, missing its `exp` claim, or once its embedded per-user token version no longer matches the user's current version (revocation).
+- `JWT_REFRESH_TTL` — Refresh-token lifetime as an ISO-8601 duration (default `P7D`, maximum `P30D`). The refresh token is delivered as an `HttpOnly` cookie; the client exchanges it at `POST /api/auth/refresh` for a fresh access token (and a rotated refresh cookie). The refresh re-reads the user, so a role change takes effect on the next refresh.
+- `REFRESH_COOKIE_SECURE` — Whether the refresh-token cookie carries the `Secure` attribute (default `true`). The `dev` profile sets it to `false` so the cookie works over plain-HTTP localhost. Keep it `true` behind an SSL-terminating reverse proxy: the browser↔proxy connection is HTTPS, so `Secure` still applies even though the proxy forwards plain HTTP internally.

--- a/docs/arc42/06-runtime-view.md
+++ b/docs/arc42/06-runtime-view.md
@@ -8,12 +8,32 @@ Browser                  AuthController      AuthService       JwtService       
   |                           |-- authenticate -->|                   |             |
   |                           |                   |--- loadUser ------|------------>|
   |                           |                   |<--- User ---------|-------------|
-  |                           |                   |-- generateToken ->|             |
-  |                           |<--- JWT token ----|<------------------|             |
-  |<-- 200 { token } ---------|                   |                   |             |
+  |                           |                   |-- issue tokens -->|             |
+  |                           |<- access+refresh -|<------------------|             |
+  |<-- 200 { token, roles } + Set-Cookie: refreshToken (HttpOnly) ----|             |
 ```
 
-## 6.2 Generate Meal Plan Suggestions
+The access token is returned in the body; the refresh token is delivered out-of-band as an
+`HttpOnly` cookie, so it is never readable by JavaScript.
+
+## 6.2 Token Refresh
+
+```
+Browser                  AuthController      AuthService       JwtService          DB
+  |-- POST /api/auth/refresh ->|                  |                   |             |
+  |   Cookie: refreshToken     |-- refresh ------>|                   |             |
+  |                            |                  |-- parse/verify -->|             |
+  |                            |                  |--- loadUser ------|------------>|
+  |                            |                  |<--- User ---------|-------------|
+  |                            |                  |-- issue tokens -->|             |
+  |                            |<- access+refresh-|<------------------|             |
+  |<-- 200 { token, roles } + Set-Cookie: refreshToken (HttpOnly) ----|             |
+```
+
+The refresh token arrives as a cookie (not a request body) and a rotated one is set on the
+response. A missing cookie yields 401.
+
+## 6.3 Generate Meal Plan Suggestions
 
 ```
 Browser                       MealPlanController    MealPlanService            SuggestionService       DB
@@ -35,7 +55,7 @@ Browser                       MealPlanController    MealPlanService            S
   |<-- 200 { plan } ------------------|                    |                           |               |
 ```
 
-## 6.3 Adjust Meal Plan
+## 6.4 Adjust Meal Plan
 
 ```
 Browser                              MealPlanController  MealPlanService         DB

--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -9,7 +9,12 @@
 - Role-based authorization: every endpoint under `/api/admin/**` additionally requires the `ADMIN` role; enforced in `SecurityConfig` and mirrored in the frontend by `AdminGuard`
 - The user's role is included as a claim in the JWT so the frontend can render admin navigation without an extra API call
 - The HMAC-SHA256 signing key is supplied via the `JWT_SECRET` environment variable (no default); a `FailureAnalyzer` surfaces missing or undersized keys as a Spring Boot `APPLICATION FAILED TO START` banner at startup
-- Tokens carry an `exp` claim and are rejected on parse if expired or if `exp` is missing. Lifetime is `JWT_TTL` (ISO-8601 duration, default `PT24H`, capped at `P30D` to prevent practically-non-expiring tokens)
+- Two token types are issued: a short-lived **access token** sent on every request and a longer-lived **refresh token** the client exchanges for a new pair at `/api/auth/refresh`. Lifetimes come from `JWT_ACCESS_TTL` (default `PT15M`) and `JWT_REFRESH_TTL` (default `P7D`), each an ISO-8601 duration capped at `P30D`
+- The refresh token is delivered as an `HttpOnly`, `SameSite=Strict` cookie scoped to `/api/auth`, so it is never readable by JavaScript; the access token is returned in the response body and held only in memory on the client. `Secure` is on by default (configurable via `REFRESH_COOKIE_SECURE`; off only for local plain-HTTP development). Logout clears the cookie via `/api/auth/logout`
+- Every token carries an `exp` claim and is rejected on parse if expired or if `exp` is missing
+- Each user has a server-side **token version** embedded in their tokens; it is bumped whenever the user's access must be revoked (e.g. a role change). A request authenticates only while the access token's version still matches the user's current version, so revocation invalidates outstanding access tokens within a short, bounded window. The current version is read through a short-lived local cache to avoid a database lookup on every request
+- Refresh is not version-gated: it re-reads the user, so a mid-session role change is reflected in the next access token — a demotion downgrades the session on the next refresh rather than forcing an immediate re-login
+- The refresh lifetime is **rolling (sliding)**: every successful refresh issues a new refresh token whose lifetime restarts from `JWT_REFRESH_TTL`. A continuously active session therefore never expires from age alone; only an inactivity gap longer than the refresh lifetime forces re-authentication
 
 ## 8.2 Domain Model
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-mysql</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/ch/ethy/recipes/AngularLocalConfiguration.java
+++ b/src/main/java/ch/ethy/recipes/AngularLocalConfiguration.java
@@ -14,7 +14,11 @@ public class AngularLocalConfiguration {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(final CorsRegistry registry) {
-        registry.addMapping("/**").allowedMethods("*").allowedOrigins("http://localhost:4200");
+        registry
+            .addMapping("/**")
+            .allowedMethods("*")
+            .allowedOrigins("http://localhost:4200")
+            .allowCredentials(true);
       }
     };
   }

--- a/src/main/java/ch/ethy/recipes/security/AuthController.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthController.java
@@ -1,9 +1,12 @@
 package ch.ethy.recipes.security;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,18 +17,39 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/auth")
 public class AuthController {
   private final AuthService authService;
+  private final RefreshTokenCookieFactory refreshTokenCookieFactory;
 
-  public AuthController(AuthService authService) {
+  public AuthController(
+      AuthService authService, RefreshTokenCookieFactory refreshTokenCookieFactory) {
     this.authService = authService;
+    this.refreshTokenCookieFactory = refreshTokenCookieFactory;
   }
 
   @PostMapping("/login")
-  public LoginResponse login(@RequestBody LoginCredentials credentials) {
+  public LoginResponse login(
+      @RequestBody LoginCredentials credentials, HttpServletResponse response) {
     try {
-      return authService.login(credentials);
+      return respondWithTokens(authService.login(credentials), response);
     } catch (AuthenticationException e) {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
     }
+  }
+
+  @PostMapping("/refresh")
+  public LoginResponse refresh(
+      @CookieValue(value = RefreshTokenCookieFactory.NAME, required = false) String refreshToken,
+      HttpServletResponse response) {
+    try {
+      return respondWithTokens(authService.refresh(refreshToken), response);
+    } catch (InvalidRefreshTokenException e) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid refresh token");
+    }
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletResponse response) {
+    response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookieFactory.clear().toString());
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/register")
@@ -37,5 +61,11 @@ public class AuthController {
       return ResponseEntity.status(HttpStatus.CONFLICT)
           .body(Map.of("conflictingFields", e.getConflictingFields()));
     }
+  }
+
+  private LoginResponse respondWithTokens(AuthTokens tokens, HttpServletResponse response) {
+    response.addHeader(
+        HttpHeaders.SET_COOKIE, refreshTokenCookieFactory.issue(tokens.refreshToken()).toString());
+    return new LoginResponse(tokens.accessToken(), tokens.roles());
   }
 }

--- a/src/main/java/ch/ethy/recipes/security/AuthService.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthService.java
@@ -3,11 +3,10 @@ package ch.ethy.recipes.security;
 import ch.ethy.recipes.user.Role;
 import ch.ethy.recipes.user.User;
 import ch.ethy.recipes.user.UserRepository;
+import io.jsonwebtoken.JwtException;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -36,26 +35,56 @@ public class AuthService {
     this.userRepository = userRepository;
   }
 
-  public LoginResponse login(LoginCredentials credentials) {
+  public AuthTokens login(LoginCredentials credentials) {
     UsernamePasswordAuthenticationToken authToken =
         new UsernamePasswordAuthenticationToken(
             credentials.usernameOrEmail(), credentials.password());
 
     Authentication authentication = authenticationManager.authenticate(authToken);
     if (!(authentication.getPrincipal()
-        instanceof org.springframework.security.core.userdetails.User user)) {
+        instanceof org.springframework.security.core.userdetails.User principal)) {
       log.error(
           "Authentication returned unexpected principal type: {}",
           authentication.getPrincipal().getClass().getName());
       throw new IllegalStateException("Authentication principal has unexpected type");
     }
-    Set<Role> roles =
-        user.getAuthorities().stream()
-            .filter(Role.class::isInstance)
-            .map(Role.class::cast)
-            .collect(Collectors.toCollection(() -> EnumSet.noneOf(Role.class)));
-    String token = jwtService.generateToken(user.getUsername(), roles);
-    return new LoginResponse(token, roles);
+    User user =
+        userRepository
+            .findByUsernameOrEmail(principal.getUsername())
+            .orElseThrow(() -> new IllegalStateException("Authenticated user no longer exists"));
+    return issueTokens(user);
+  }
+
+  public AuthTokens refresh(String refreshToken) {
+    if (refreshToken == null || refreshToken.isBlank()) {
+      throw new InvalidRefreshTokenException("No refresh token provided");
+    }
+    JwtService.TokenData tokenData;
+    try {
+      tokenData = jwtService.parseToken(refreshToken);
+    } catch (JwtException e) {
+      throw new InvalidRefreshTokenException("Refresh token is malformed or expired");
+    }
+    if (tokenData.type() != TokenType.REFRESH) {
+      throw new InvalidRefreshTokenException("Token is not a refresh token");
+    }
+    // Only the access token is version-gated. A refresh always re-reads the user, so the new
+    // access token reflects the current role and token version even if the role changed since
+    // this refresh token was issued (e.g. a mid-session demotion is picked up here).
+    User user =
+        userRepository
+            .findById(tokenData.userId())
+            .orElseThrow(() -> new InvalidRefreshTokenException("User no longer exists"));
+    return issueTokens(user);
+  }
+
+  private AuthTokens issueTokens(User user) {
+    Set<Role> roles = user.getRoles();
+    String accessToken =
+        jwtService.generateAccessToken(
+            user.getId(), user.getUsername(), roles, user.getTokenVersion());
+    String refreshToken = jwtService.generateRefreshToken(user.getId(), user.getUsername());
+    return new AuthTokens(accessToken, refreshToken, roles);
   }
 
   public void register(RegistrationDetails registrationDetails) {

--- a/src/main/java/ch/ethy/recipes/security/AuthTokens.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthTokens.java
@@ -1,0 +1,7 @@
+package ch.ethy.recipes.security;
+
+import ch.ethy.recipes.user.Role;
+import java.util.Set;
+
+/** Internal result of authentication: the tokens to hand back plus the user's roles. */
+public record AuthTokens(String accessToken, String refreshToken, Set<Role> roles) {}

--- a/src/main/java/ch/ethy/recipes/security/InvalidRefreshTokenException.java
+++ b/src/main/java/ch/ethy/recipes/security/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package ch.ethy.recipes.security;
+
+/** Thrown when a presented refresh token is missing, malformed, of the wrong type, or revoked. */
+public class InvalidRefreshTokenException extends RuntimeException {
+  public InvalidRefreshTokenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/ch/ethy/recipes/security/JWTFilter.java
+++ b/src/main/java/ch/ethy/recipes/security/JWTFilter.java
@@ -16,9 +16,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Service
 public class JWTFilter extends OncePerRequestFilter {
   private final JwtService jwtService;
+  private final TokenVersionService tokenVersionService;
 
-  public JWTFilter(JwtService jwtService) {
+  public JWTFilter(JwtService jwtService, TokenVersionService tokenVersionService) {
     this.jwtService = jwtService;
+    this.tokenVersionService = tokenVersionService;
   }
 
   @Override
@@ -34,13 +36,17 @@ public class JWTFilter extends OncePerRequestFilter {
       }
       try {
         JwtService.TokenData tokenData = jwtService.parseToken(token);
+        if (!isUsableAccessToken(tokenData)) {
+          response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
+          return;
+        }
         UserDetails userDetails = new User(tokenData.username(), "", tokenData.roles());
         Authentication authentication = new JWTAuthenticationToken(userDetails, token);
 
         if (SecurityContextHolder.getContext().getAuthentication() == null) {
           SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-      } catch (JwtException e) {
+      } catch (JwtException | UnknownUserException e) {
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
         return;
       }
@@ -49,5 +55,12 @@ public class JWTFilter extends OncePerRequestFilter {
     // Requests without a Bearer header pass through unauthenticated; Spring Security's
     // authorizeHttpRequests rules decide whether the target endpoint requires auth.
     filterChain.doFilter(request, response);
+  }
+
+  // Only access tokens authenticate requests, and only while their version still matches the
+  // user's current token version — a revocation bumps that version and invalidates the token.
+  private boolean isUsableAccessToken(JwtService.TokenData tokenData) {
+    return tokenData.type() == TokenType.ACCESS
+        && tokenData.version() == tokenVersionService.getCurrentVersion(tokenData.userId());
   }
 }

--- a/src/main/java/ch/ethy/recipes/security/JwtFailureAnalyzer.java
+++ b/src/main/java/ch/ethy/recipes/security/JwtFailureAnalyzer.java
@@ -9,8 +9,9 @@ public class JwtFailureAnalyzer extends AbstractFailureAnalyzer<JwtMisconfigurat
   protected FailureAnalysis analyze(Throwable rootFailure, JwtMisconfigurationException cause) {
     String action =
         "Check JWT configuration. JWT_SECRET must be a base64-encoded HMAC-SHA256 key (generate"
-            + " one with: openssl rand -base64 48). JWT_TTL must be a positive ISO-8601 duration"
-            + " no longer than P30D (default: PT24H).";
+            + " one with: openssl rand -base64 48). JWT_ACCESS_TTL and JWT_REFRESH_TTL must each be"
+            + " a positive ISO-8601 duration no longer than P30D (defaults: PT15M access, P7D"
+            + " refresh).";
     return new FailureAnalysis(cause.getMessage(), action, cause);
   }
 }

--- a/src/main/java/ch/ethy/recipes/security/JwtService.java
+++ b/src/main/java/ch/ethy/recipes/security/JwtService.java
@@ -2,14 +2,9 @@ package ch.ethy.recipes.security;
 
 import ch.ethy.recipes.user.Role;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.IncorrectClaimException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.MissingClaimException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.SignatureException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -28,11 +23,21 @@ public class JwtService {
   private static final int MIN_KEY_BYTES = 32;
   private static final Duration MAX_TTL = Duration.ofDays(30);
 
+  private static final String SUBJECT = "User Details";
+  private static final String CLAIM_USER_ID = "uid";
+  private static final String CLAIM_USERNAME = "usernameOrEmail";
+  private static final String CLAIM_ROLES = "roles";
+  private static final String CLAIM_VERSION = "ver";
+  private static final String CLAIM_TYPE = "type";
+
   private final SecretKey key;
-  private final Duration ttl;
+  private final Duration accessTtl;
+  private final Duration refreshTtl;
 
   public JwtService(
-      @Value("${jwt.secret:}") String encodedKey, @Value("${jwt.ttl:PT24H}") Duration ttl) {
+      @Value("${auth.jwt.secret}") String encodedKey,
+      @Value("${auth.jwt.access-ttl}") Duration accessTtl,
+      @Value("${auth.jwt.refresh-ttl}") Duration refreshTtl) {
     if (encodedKey == null || encodedKey.isBlank()) {
       throw new JwtMisconfigurationException(
           "jwt.secret is not configured. Set the JWT_SECRET environment variable to a"
@@ -51,53 +56,110 @@ public class JwtService {
               + decoded.length
               + " byte(s).");
     }
+    this.key = new SecretKeySpec(decoded, "HmacSHA256");
+    this.accessTtl = validateTtl(accessTtl, "jwt.access-ttl (JWT_ACCESS_TTL)");
+    this.refreshTtl = validateTtl(refreshTtl, "jwt.refresh-ttl (JWT_REFRESH_TTL)");
+  }
+
+  private static Duration validateTtl(Duration ttl, String label) {
     if (ttl == null || !ttl.isPositive()) {
       throw new JwtMisconfigurationException(
-          "jwt.ttl (JWT_TTL) must be a positive ISO-8601 duration (e.g. PT24H); got " + ttl + ".");
+          label + " must be a positive ISO-8601 duration (e.g. PT15M); got " + ttl + ".");
     }
     if (ttl.compareTo(MAX_TTL) > 0) {
       throw new JwtMisconfigurationException(
-          "jwt.ttl (JWT_TTL) must not exceed P30D (30 days); got " + ttl + ".");
+          label + " must not exceed P30D (30 days); got " + ttl + ".");
     }
-    this.key = new SecretKeySpec(decoded, "HmacSHA256");
-    this.ttl = ttl;
+    return ttl;
   }
 
-  public String generateToken(String username, Set<Role> roles) {
+  public String generateAccessToken(long userId, String username, Set<Role> roles, int version) {
+    return build(userId, username, roles, version, TokenType.ACCESS, accessTtl);
+  }
+
+  public String generateRefreshToken(long userId, String username) {
+    // Refresh tokens carry neither a roles nor a version claim: the refresh path re-reads the user
+    // from the database rather than trusting the token, so either stamp would be dead, misleading
+    // data.
+    return build(userId, username, null, null, TokenType.REFRESH, refreshTtl);
+  }
+
+  private String build(
+      long userId,
+      String username,
+      Set<Role> roles,
+      Integer version,
+      TokenType type,
+      Duration ttl) {
     Instant now = Instant.now();
-    return Jwts.builder()
-        .subject("User Details")
-        .claim("usernameOrEmail", username)
-        .claim("roles", roles.stream().map(Role::name).toList())
-        .issuedAt(Date.from(now))
-        .expiration(Date.from(now.plus(ttl)))
-        .issuer("recipes")
-        .signWith(key)
-        .compact();
+    var builder =
+        Jwts.builder()
+            .subject(SUBJECT)
+            .claim(CLAIM_USER_ID, userId)
+            .claim(CLAIM_USERNAME, username)
+            .claim(CLAIM_TYPE, type.name())
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plus(ttl)))
+            .issuer("recipes")
+            .signWith(key);
+    if (roles != null) {
+      builder.claim(CLAIM_ROLES, roles.stream().map(Role::name).toList());
+    }
+    if (version != null) {
+      builder.claim(CLAIM_VERSION, version);
+    }
+    return builder.compact();
   }
 
-  public TokenData parseToken(String token)
-      throws SignatureException,
-          MalformedJwtException,
-          ExpiredJwtException,
-          UnsupportedJwtException,
-          IncorrectClaimException,
-          MissingClaimException {
-    Claims claims =
-        Jwts.parser()
-            .verifyWith(this.key)
-            .requireSubject("User Details")
-            .build()
-            .parseSignedClaims(token)
-            .getPayload();
+  public TokenData parseToken(String token) {
+    Claims claims = parseClaims(token);
+    validateRequiredClaims(claims);
+    TokenType type = requireType(claims);
+    Integer version = claims.get(CLAIM_VERSION, Integer.class);
+    if (type == TokenType.ACCESS && version == null) {
+      throw new MalformedJwtException("Required claim 'ver' is missing");
+    }
+    return new TokenData(
+        claims.get(CLAIM_USER_ID, Long.class),
+        claims.get(CLAIM_USERNAME, String.class),
+        toRoles(claims.get(CLAIM_ROLES)),
+        version == null ? 0 : version,
+        type);
+  }
+
+  private Claims parseClaims(String token) {
+    return Jwts.parser()
+        .verifyWith(this.key)
+        .requireSubject(SUBJECT)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+
+  private static void validateRequiredClaims(Claims claims) {
     if (claims.getExpiration() == null) {
       throw new MalformedJwtException("Required claim 'exp' is missing");
     }
-    String username = claims.get("usernameOrEmail", String.class);
-    if (username == null) {
-      throw new MalformedJwtException("Required claim 'usernameOrEmail' is missing");
+    requireClaim(claims, CLAIM_USERNAME, String.class);
+    requireClaim(claims, CLAIM_USER_ID, Long.class);
+  }
+
+  private static <T> void requireClaim(Claims claims, String name, Class<T> type) {
+    if (claims.get(name, type) == null) {
+      throw new MalformedJwtException("Required claim '" + name + "' is missing");
     }
-    return new TokenData(username, toRoles(claims.get("roles")));
+  }
+
+  private static TokenType requireType(Claims claims) {
+    String raw = claims.get(CLAIM_TYPE, String.class);
+    if (raw != null) {
+      try {
+        return TokenType.valueOf(raw);
+      } catch (IllegalArgumentException e) {
+        // fall through to the malformed-token error below
+      }
+    }
+    throw new MalformedJwtException("Required claim 'type' is missing or invalid");
   }
 
   private static Set<Role> toRoles(Object raw) {
@@ -120,5 +182,6 @@ public class JwtService {
     return null;
   }
 
-  public record TokenData(String username, Set<Role> roles) {}
+  public record TokenData(
+      long userId, String username, Set<Role> roles, int version, TokenType type) {}
 }

--- a/src/main/java/ch/ethy/recipes/security/LoginResponse.java
+++ b/src/main/java/ch/ethy/recipes/security/LoginResponse.java
@@ -4,7 +4,10 @@ import ch.ethy.recipes.user.Role;
 import java.util.Set;
 
 /**
- * Returned to the client after a successful login.
+ * Returned to the client after a successful login or token refresh.
+ *
+ * <p>{@code token} is the short-lived access token sent on every request. The refresh token is not
+ * in the body — it is delivered as an {@code HttpOnly} cookie so it is never exposed to JavaScript.
  *
  * <p>The {@code roles} field is a convenience hint for UI rendering only (e.g., deciding which
  * navigation items to show). It is <strong>not</strong> authoritative — every protected request is

--- a/src/main/java/ch/ethy/recipes/security/RefreshTokenCookieFactory.java
+++ b/src/main/java/ch/ethy/recipes/security/RefreshTokenCookieFactory.java
@@ -1,0 +1,47 @@
+package ch.ethy.recipes.security;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds the {@code Set-Cookie} for the refresh token. The cookie is {@code HttpOnly} (invisible to
+ * JavaScript, so an XSS payload cannot read it), {@code SameSite=Strict} (not sent on cross-site
+ * requests), and scoped to {@code /api/auth} so it travels only to the auth endpoints. {@code
+ * Secure} is configurable so local development over plain HTTP still works.
+ */
+@Component
+public class RefreshTokenCookieFactory {
+  public static final String NAME = "refreshToken";
+  private static final String PATH = "/api/auth";
+
+  private final Duration refreshTtl;
+  private final boolean secure;
+
+  public RefreshTokenCookieFactory(
+      @Value("${auth.jwt.refresh-ttl}") Duration refreshTtl,
+      @Value("${auth.refresh-cookie.secure}") boolean secure) {
+    this.refreshTtl = refreshTtl;
+    this.secure = secure;
+  }
+
+  public ResponseCookie issue(String token) {
+    // maxAge is the full refresh TTL on every issuance, so each refresh restarts the clock:
+    // sessions are rolling (sliding), not absolute. An active user stays logged in indefinitely;
+    // only inactivity longer than the TTL forces re-authentication.
+    return base(token).maxAge(refreshTtl).build();
+  }
+
+  public ResponseCookie clear() {
+    return base("").maxAge(0).build();
+  }
+
+  private ResponseCookie.ResponseCookieBuilder base(String value) {
+    return ResponseCookie.from(NAME, value)
+        .httpOnly(true)
+        .secure(secure)
+        .sameSite("Strict")
+        .path(PATH);
+  }
+}

--- a/src/main/java/ch/ethy/recipes/security/TokenType.java
+++ b/src/main/java/ch/ethy/recipes/security/TokenType.java
@@ -1,0 +1,7 @@
+package ch.ethy.recipes.security;
+
+/** Distinguishes a short-lived access token from a long-lived refresh token. */
+public enum TokenType {
+  ACCESS,
+  REFRESH
+}

--- a/src/main/java/ch/ethy/recipes/security/TokenVersionService.java
+++ b/src/main/java/ch/ethy/recipes/security/TokenVersionService.java
@@ -1,0 +1,51 @@
+package ch.ethy.recipes.security;
+
+import ch.ethy.recipes.user.UserRepository;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import org.springframework.stereotype.Service;
+
+/**
+ * Reads and revokes the per-user token version that gates access-token validity.
+ *
+ * <p>The current version is cached locally (Caffeine) so the common path — validating a request —
+ * does not hit the database every time. Cache entries expire shortly after they are written, which
+ * bounds how long a stale version can be served after another instance revokes a user's tokens;
+ * {@link #revokeTokens} also evicts the local entry so the revoking instance sees the change
+ * immediately.
+ */
+@Service
+public class TokenVersionService {
+  private static final Duration CACHE_TTL = Duration.ofSeconds(10);
+  private static final long CACHE_MAX_SIZE = 100_000;
+
+  private final UserRepository userRepository;
+  private final Cache<Long, Integer> versionCache =
+      Caffeine.newBuilder().expireAfterWrite(CACHE_TTL).maximumSize(CACHE_MAX_SIZE).build();
+
+  public TokenVersionService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public int getCurrentVersion(long userId) {
+    return versionCache.get(
+        userId,
+        id -> userRepository.findTokenVersionById(id).orElseThrow(UnknownUserException::new));
+  }
+
+  /**
+   * Increments the user's token version, invalidating their outstanding <em>access</em> tokens.
+   * Refresh tokens are not version-gated and stay usable until they expire (hard revocation of a
+   * refresh token comes from disabling the user, handled by the admin flow).
+   *
+   * @throws UnknownUserException if no user has the given id, so a revocation that affected nothing
+   *     fails fast rather than silently no-opping
+   */
+  public void revokeTokens(long userId) {
+    if (userRepository.incrementTokenVersion(userId) == 0) {
+      throw new UnknownUserException();
+    }
+    versionCache.invalidate(userId);
+  }
+}

--- a/src/main/java/ch/ethy/recipes/security/UnknownUserException.java
+++ b/src/main/java/ch/ethy/recipes/security/UnknownUserException.java
@@ -1,0 +1,8 @@
+package ch.ethy.recipes.security;
+
+/** Thrown when a token references a user that no longer exists. */
+public class UnknownUserException extends RuntimeException {
+  public UnknownUserException() {
+    super("Token references a user that no longer exists");
+  }
+}

--- a/src/main/java/ch/ethy/recipes/user/User.java
+++ b/src/main/java/ch/ethy/recipes/user/User.java
@@ -30,6 +30,11 @@ public class User extends BaseEntity {
   @Nonnull
   private Set<Role> roles = new HashSet<>(List.of(USER));
 
+  // Bumped only via UserRepository#incrementTokenVersion (an atomic DB increment), never through a
+  // setter, so concurrent revocations cannot lose updates.
+  @Column(name = "token_version", nullable = false)
+  private int tokenVersion = 0;
+
   public String getUsername() {
     return username;
   }
@@ -56,6 +61,10 @@ public class User extends BaseEntity {
 
   public Set<Role> getRoles() {
     return roles;
+  }
+
+  public int getTokenVersion() {
+    return tokenVersion;
   }
 
   public void addRole(Role role) {

--- a/src/main/java/ch/ethy/recipes/user/UserRepository.java
+++ b/src/main/java/ch/ethy/recipes/user/UserRepository.java
@@ -2,8 +2,10 @@ package ch.ethy.recipes.user;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -13,4 +15,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByUsername(String username);
 
   boolean existsByEmail(String email);
+
+  @Query("SELECT u.tokenVersion FROM User u WHERE u.id = :id")
+  Optional<Integer> findTokenVersionById(long id);
+
+  @Modifying
+  @Transactional
+  @Query("UPDATE User u SET u.tokenVersion = u.tokenVersion + 1 WHERE u.id = :id")
+  int incrementTokenVersion(long id);
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,3 +3,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+auth:
+  refresh-cookie:
+    secure: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,10 @@ spring:
       media-types:
         woff2: "font/woff2"
 
-jwt:
-  secret: ${JWT_SECRET:}
-  ttl: ${JWT_TTL:PT24H}
+auth:
+  jwt:
+    secret: ${JWT_SECRET:}
+    access-ttl: ${JWT_ACCESS_TTL:PT15M}
+    refresh-ttl: ${JWT_REFRESH_TTL:P7D}
+  refresh-cookie:
+    secure: ${REFRESH_COOKIE_SECURE:true}

--- a/src/main/resources/db/migration/V6__add_token_version_to_users.sql
+++ b/src/main/resources/db/migration/V6__add_token_version_to_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ADD COLUMN token_version INT NOT NULL DEFAULT 0;

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -4,6 +4,7 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { authenticationInterceptor } from './security/authentication-interceptor';
+import { refreshInterceptor } from './security/refresh-interceptor';
 import {
   MAT_FORM_FIELD_DEFAULT_OPTIONS,
   MatFormFieldDefaultOptions,
@@ -13,7 +14,7 @@ import { MAT_CARD_CONFIG, MatCardConfig } from '@angular/material/card';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideHttpClient(withInterceptors([authenticationInterceptor])),
+    provideHttpClient(withInterceptors([authenticationInterceptor, refreshInterceptor])),
     provideRouter(routes),
     {
       provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,

--- a/src/main/webapp/app/security/auth.service.spec.ts
+++ b/src/main/webapp/app/security/auth.service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { Mocked } from 'vitest';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+  let routerSpy: Mocked<Pick<Router, 'navigate'>>;
+
+  beforeEach(() => {
+    routerSpy = { navigate: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('has no access token before authenticating', () => {
+    expect(service.getAccessToken()).toBeNull();
+  });
+
+  it('refresh sends credentials, holds the access token in memory, and returns it', async () => {
+    const promise = firstValueFrom(service.refresh());
+
+    const req = httpMock.expectOne('/api/auth/refresh');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.withCredentials).toBe(true);
+    req.flush({ token: 'new-access', roles: ['USER'] });
+
+    const token = await promise;
+    expect(token).toBe('new-access');
+    expect(service.getAccessToken()).toBe('new-access');
+  });
+
+  it('dedupes concurrent refreshes into a single request and reuses none afterwards', async () => {
+    const first = firstValueFrom(service.refresh());
+    const second = firstValueFrom(service.refresh());
+
+    // expectOne fails if a second POST was issued: concurrent callers must share one request.
+    httpMock.expectOne('/api/auth/refresh').flush({ token: 'shared', roles: ['USER'] });
+
+    expect(await first).toBe('shared');
+    expect(await second).toBe('shared');
+
+    // Once the in-flight refresh settles, the next call starts a fresh request.
+    const third = firstValueFrom(service.refresh());
+    httpMock.expectOne('/api/auth/refresh').flush({ token: 'again', roles: ['USER'] });
+    expect(await third).toBe('again');
+  });
+
+  it('logout clears the in-memory token, asks the backend to drop the cookie, and routes to login', () => {
+    service.logout();
+
+    const req = httpMock.expectOne('/api/auth/logout');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.withCredentials).toBe(true);
+    req.flush(null);
+
+    expect(service.getAccessToken()).toBeNull();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['login']);
+  });
+});

--- a/src/main/webapp/app/security/auth.service.ts
+++ b/src/main/webapp/app/security/auth.service.ts
@@ -1,6 +1,15 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { catchError, firstValueFrom, of, switchMap } from 'rxjs';
+import {
+  catchError,
+  finalize,
+  firstValueFrom,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  switchMap,
+} from 'rxjs';
 import { Router } from '@angular/router';
 
 export interface RegistrationDetails {
@@ -13,12 +22,27 @@ export interface DuplicateUserError {
   conflictingFields: string[];
 }
 
+export interface LoginResponse {
+  token: string;
+  roles: string[];
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
   private http = inject(HttpClient);
   private router = inject(Router);
+
+  // The access token lives only in memory: it is never written to localStorage, so an XSS payload
+  // cannot exfiltrate it. After a page reload it starts null, so the first protected request 401s
+  // and the refresh interceptor transparently re-acquires it from the refresh cookie.
+  private accessToken: string | null = null;
+
+  // Holds the in-flight refresh so a burst of simultaneous 401s (e.g. several requests firing
+  // after a reload) shares one POST /api/auth/refresh instead of each rotating the cookie. Reset
+  // when the request settles so the next burst starts fresh.
+  private refreshInFlight$: Observable<string> | null = null;
 
   async register(details: RegistrationDetails): Promise<DuplicateUserError | boolean> {
     return firstValueFrom(
@@ -32,5 +56,34 @@ export class AuthService {
         }),
       ),
     );
+  }
+
+  getAccessToken(): string | null {
+    return this.accessToken;
+  }
+
+  refresh(): Observable<string> {
+    // The refresh token rides along as an HttpOnly cookie; withCredentials lets the browser send it.
+    this.refreshInFlight$ ??= this.http
+      .post<LoginResponse>('/api/auth/refresh', {}, { withCredentials: true })
+      .pipe(
+        map((response) => {
+          this.accessToken = response.token;
+          return response.token;
+        }),
+        finalize(() => (this.refreshInFlight$ = null)),
+        shareReplay(1),
+      );
+    return this.refreshInFlight$;
+  }
+
+  logout(): void {
+    // Best-effort cookie clear; local state is dropped regardless of the backend result.
+    this.http
+      .post('/api/auth/logout', {}, { withCredentials: true })
+      .pipe(catchError(() => of(null)))
+      .subscribe();
+    this.accessToken = null;
+    this.router.navigate(['login']);
   }
 }

--- a/src/main/webapp/app/security/authentication-interceptor.spec.ts
+++ b/src/main/webapp/app/security/authentication-interceptor.spec.ts
@@ -1,32 +1,25 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpInterceptorFn, HttpRequest } from '@angular/common/http';
+import { of } from 'rxjs';
+import { Mocked } from 'vitest';
 
 import { authenticationInterceptor } from './authentication-interceptor';
-import { LocalStorage } from '../utility/local-storage';
-import { Mocked } from 'vitest';
-import { of } from 'rxjs';
+import { AuthService } from './auth.service';
 
 describe('authenticationInterceptor', () => {
   const interceptor: HttpInterceptorFn = (req, next) =>
     TestBed.runInInjectionContext(() => authenticationInterceptor(req, next));
-  let localStorageServiceSpy: Mocked<LocalStorage>;
+  let authServiceSpy: Mocked<Pick<AuthService, 'getAccessToken'>>;
 
   beforeEach(() => {
-    const spy: Mocked<LocalStorage> = { getItem: vi.fn(), setItem: vi.fn() };
-
+    authServiceSpy = { getAccessToken: vi.fn() };
     TestBed.configureTestingModule({
-      providers: [{ provide: LocalStorage, useValue: spy }],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }],
     });
-
-    localStorageServiceSpy = TestBed.inject(LocalStorage) as Mocked<LocalStorage>;
   });
 
-  it('should be created', () => {
-    expect(interceptor).toBeTruthy();
-  });
-
-  it('should add the authentication header if JWT is present in localStorage', () => {
-    localStorageServiceSpy.getItem.mockReturnValue('token');
+  it('adds the authentication header when an access token is held', () => {
+    authServiceSpy.getAccessToken.mockReturnValue('token');
     const httpRequest = new HttpRequest<unknown>('GET', '/api/test');
     let modifiedRequest: HttpRequest<unknown> = httpRequest;
     interceptor(httpRequest, (req) => {
@@ -37,8 +30,8 @@ describe('authenticationInterceptor', () => {
     expect(modifiedRequest.headers.get('Authorization')).toEqual('Bearer token');
   });
 
-  it('should not add the authentication header if JWT is not present in localStorage', () => {
-    localStorageServiceSpy.getItem.mockReturnValue(null);
+  it('does not add the authentication header when no access token is held', () => {
+    authServiceSpy.getAccessToken.mockReturnValue(null);
     const httpRequest = new HttpRequest<unknown>('GET', '/api/test');
     let modifiedRequest: HttpRequest<unknown> = httpRequest;
     interceptor(httpRequest, (req) => {

--- a/src/main/webapp/app/security/authentication-interceptor.ts
+++ b/src/main/webapp/app/security/authentication-interceptor.ts
@@ -1,19 +1,17 @@
 import { HttpInterceptorFn } from '@angular/common/http';
-import { LocalStorage } from '../utility/local-storage';
 import { inject } from '@angular/core';
+import { AuthService } from './auth.service';
 
 export const authenticationInterceptor: HttpInterceptorFn = (req, next) => {
-  const localStorageService = inject(LocalStorage);
+  const accessToken = inject(AuthService).getAccessToken();
 
-  const jwt = localStorageService.getItem('jwt');
-
-  if (!jwt) {
+  if (!accessToken) {
     return next(req);
   }
 
   return next(
     req.clone({
-      headers: req.headers.set('Authorization', `Bearer ${jwt}`),
+      headers: req.headers.set('Authorization', `Bearer ${accessToken}`),
     }),
   );
 };

--- a/src/main/webapp/app/security/refresh-interceptor.spec.ts
+++ b/src/main/webapp/app/security/refresh-interceptor.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpErrorResponse,
+  HttpHandlerFn,
+  HttpHeaders,
+  HttpInterceptorFn,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { firstValueFrom, of, throwError } from 'rxjs';
+import { Mocked } from 'vitest';
+
+import { refreshInterceptor } from './refresh-interceptor';
+import { AuthService } from './auth.service';
+
+describe('refreshInterceptor', () => {
+  const interceptor: HttpInterceptorFn = (req, next) =>
+    TestBed.runInInjectionContext(() => refreshInterceptor(req, next));
+  let authServiceSpy: Mocked<Pick<AuthService, 'refresh' | 'logout' | 'getAccessToken'>>;
+
+  beforeEach(() => {
+    authServiceSpy = { refresh: vi.fn(), logout: vi.fn(), getAccessToken: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useValue: authServiceSpy }],
+    });
+  });
+
+  it('refreshes and retries the original request with the new token on 401', async () => {
+    authServiceSpy.refresh.mockReturnValue(of('new-access'));
+    const req = new HttpRequest('GET', '/api/recipes');
+    let retried: HttpRequest<unknown> | undefined;
+    const next: HttpHandlerFn = (r) => {
+      if (r.headers.get('Authorization') === 'Bearer new-access') {
+        retried = r;
+        return of(new HttpResponse({ status: 200 }));
+      }
+      return throwError(() => new HttpErrorResponse({ status: 401 }));
+    };
+
+    const result = await firstValueFrom(interceptor(req, next));
+
+    expect(authServiceSpy.refresh).toHaveBeenCalledOnce();
+    expect(retried).toBeDefined();
+    expect((result as HttpResponse<unknown>).status).toBe(200);
+  });
+
+  it('retries with the current token without refreshing when it advanced since the request was sent', async () => {
+    authServiceSpy.getAccessToken.mockReturnValue('fresh');
+    const req = new HttpRequest('GET', '/api/recipes', {
+      headers: new HttpHeaders({ Authorization: 'Bearer stale' }),
+    });
+    let retried: HttpRequest<unknown> | undefined;
+    const next: HttpHandlerFn = (r) => {
+      if (r.headers.get('Authorization') === 'Bearer fresh') {
+        retried = r;
+        return of(new HttpResponse({ status: 200 }));
+      }
+      return throwError(() => new HttpErrorResponse({ status: 401 }));
+    };
+
+    const result = await firstValueFrom(interceptor(req, next));
+
+    expect(authServiceSpy.refresh).not.toHaveBeenCalled();
+    expect(retried).toBeDefined();
+    expect((result as HttpResponse<unknown>).status).toBe(200);
+  });
+
+  it('logs out and propagates the error when the refresh itself fails', async () => {
+    authServiceSpy.refresh.mockReturnValue(throwError(() => new Error('refresh failed')));
+    const next: HttpHandlerFn = () => throwError(() => new HttpErrorResponse({ status: 401 }));
+
+    await expect(
+      firstValueFrom(interceptor(new HttpRequest('GET', '/api/recipes'), next)),
+    ).rejects.toBeTruthy();
+    expect(authServiceSpy.logout).toHaveBeenCalledOnce();
+  });
+
+  it('logs out when the retried request also returns 401', async () => {
+    authServiceSpy.refresh.mockReturnValue(of('new-access'));
+    // next always rejects with 401, including the retry.
+    const next: HttpHandlerFn = () => throwError(() => new HttpErrorResponse({ status: 401 }));
+
+    await expect(
+      firstValueFrom(interceptor(new HttpRequest('GET', '/api/recipes'), next)),
+    ).rejects.toBeTruthy();
+    expect(authServiceSpy.logout).toHaveBeenCalledOnce();
+  });
+
+  it('does not attempt a refresh for auth endpoints', async () => {
+    const next: HttpHandlerFn = () => throwError(() => new HttpErrorResponse({ status: 401 }));
+
+    await expect(
+      firstValueFrom(interceptor(new HttpRequest('POST', '/api/auth/login', {}), next)),
+    ).rejects.toBeTruthy();
+    expect(authServiceSpy.refresh).not.toHaveBeenCalled();
+  });
+
+  it('passes non-401 errors through untouched', async () => {
+    const next: HttpHandlerFn = () => throwError(() => new HttpErrorResponse({ status: 500 }));
+
+    await expect(
+      firstValueFrom(interceptor(new HttpRequest('GET', '/api/recipes'), next)),
+    ).rejects.toBeTruthy();
+    expect(authServiceSpy.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/webapp/app/security/refresh-interceptor.ts
+++ b/src/main/webapp/app/security/refresh-interceptor.ts
@@ -1,0 +1,57 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { catchError, switchMap, throwError } from 'rxjs';
+import { AuthService } from './auth.service';
+
+// On a 401 for a protected request, obtain a usable access token and retry the request once. Auth
+// endpoints are excluded so a failed login/refresh is not retried. A failed refresh, or a retry
+// that still 401s, logs the user out.
+//
+// Two paths avoid redundant refreshes when several requests 401 around the same time:
+//  - if a concurrent refresh already minted a newer token while this request was in flight (the
+//    current token differs from the one the request was sent with), retry with it directly;
+//  - otherwise exchange the refresh cookie for a fresh token. The cookie is HttpOnly and invisible
+//    to JS, so we cannot pre-check for a session: with none this costs one extra round-trip (the
+//    refresh also 401s) before logout — an accepted trade-off for keeping the cookie opaque.
+//    AuthService collapses simultaneous refreshes into a single request.
+export const refreshInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const sentToken = req.headers.get('Authorization');
+
+  return next(req).pipe(
+    catchError((error: unknown) => {
+      if (!isUnauthorized(error) || req.url.includes('/api/auth/')) {
+        return throwError(() => error);
+      }
+
+      const retryWith = (accessToken: string) =>
+        next(
+          req.clone({ headers: req.headers.set('Authorization', `Bearer ${accessToken}`) }),
+        ).pipe(
+          catchError((retryError: unknown) => {
+            if (isUnauthorized(retryError)) {
+              authService.logout();
+            }
+            return throwError(() => retryError);
+          }),
+        );
+
+      const current = authService.getAccessToken();
+      if (current && `Bearer ${current}` !== sentToken) {
+        return retryWith(current);
+      }
+
+      return authService.refresh().pipe(
+        catchError((refreshError: unknown) => {
+          authService.logout();
+          return throwError(() => refreshError);
+        }),
+        switchMap(retryWith),
+      );
+    }),
+  );
+};
+
+function isUnauthorized(error: unknown): boolean {
+  return error instanceof HttpErrorResponse && error.status === 401;
+}

--- a/src/main/webapp/app/utility/local-storage.ts
+++ b/src/main/webapp/app/utility/local-storage.ts
@@ -12,4 +12,8 @@ export class LocalStorage {
     const item = localStorage.getItem(key);
     return item ? JSON.parse(item) : null;
   }
+
+  public removeItem(key: string) {
+    localStorage.removeItem(key);
+  }
 }

--- a/src/test/java/ch/ethy/recipes/security/AuthControllerTest.java
+++ b/src/test/java/ch/ethy/recipes/security/AuthControllerTest.java
@@ -1,0 +1,118 @@
+package ch.ethy.recipes.security;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.ethy.recipes.user.Role;
+import jakarta.servlet.http.Cookie;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(AuthController.class)
+@Import(RefreshTokenCookieFactory.class)
+class AuthControllerTest {
+
+  @TestConfiguration
+  static class SecurityTestConfig {
+    @Bean
+    SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+      return http.csrf(AbstractHttpConfigurer::disable)
+          .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .build();
+    }
+  }
+
+  @Autowired private MockMvc mockMvc;
+  @MockitoBean private AuthService authService;
+
+  // JWTFilter is pulled into the slice and needs these collaborators.
+  @MockitoBean private JwtService jwtService;
+  @MockitoBean private TokenVersionService tokenVersionService;
+
+  @Test
+  void loginSetsTheRefreshCookieAndReturnsTheAccessToken() throws Exception {
+    when(authService.login(any()))
+        .thenReturn(new AuthTokens("access-1", "refresh-1", Set.of(Role.USER)));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"usernameOrEmail\":\"alice\",\"password\":\"pw\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").value("access-1"))
+            .andReturn();
+
+    String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+    assertNotNull(setCookie);
+    assertTrue(setCookie.contains("refreshToken=refresh-1"), setCookie);
+    assertTrue(setCookie.contains("HttpOnly"), setCookie);
+  }
+
+  @Test
+  void loginWithBadCredentialsReturns401() throws Exception {
+    when(authService.login(any())).thenThrow(new BadCredentialsException("nope"));
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"usernameOrEmail\":\"alice\",\"password\":\"wrong\"}"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void refreshWithoutACookieReturns401() throws Exception {
+    when(authService.refresh(null)).thenThrow(new InvalidRefreshTokenException("missing"));
+
+    mockMvc.perform(post("/api/auth/refresh")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void refreshWithACookieRotatesItAndReturnsTheAccessToken() throws Exception {
+    when(authService.refresh("old-refresh"))
+        .thenReturn(new AuthTokens("access-2", "refresh-2", Set.of(Role.USER)));
+
+    MvcResult result =
+        mockMvc
+            .perform(post("/api/auth/refresh").cookie(new Cookie("refreshToken", "old-refresh")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").value("access-2"))
+            .andReturn();
+
+    String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+    assertNotNull(setCookie);
+    assertTrue(setCookie.contains("refreshToken=refresh-2"), setCookie);
+  }
+
+  @Test
+  void logoutClearsTheRefreshCookie() throws Exception {
+    MvcResult result =
+        mockMvc.perform(post("/api/auth/logout")).andExpect(status().isNoContent()).andReturn();
+
+    String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+    assertNotNull(setCookie);
+    assertTrue(setCookie.contains("refreshToken="), setCookie);
+    assertTrue(setCookie.contains("Max-Age=0"), setCookie);
+  }
+}

--- a/src/test/java/ch/ethy/recipes/security/AuthServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/security/AuthServiceTest.java
@@ -8,11 +8,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import ch.ethy.recipes.user.Role;
+import ch.ethy.recipes.user.User;
 import ch.ethy.recipes.user.UserRepository;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.jsonwebtoken.MalformedJwtException;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,19 +58,27 @@ class AuthServiceTest {
   }
 
   @Test
-  void loginAsksJwtServiceToTokenizeAuthenticatedUsernameAndRoles() {
+  void loginIssuesAccessAndRefreshTokensForTheAuthenticatedUser() {
     var principal =
         new org.springframework.security.core.userdetails.User(
             "alice", "pw", Set.of(Role.USER, Role.ADMIN));
     Authentication authenticated =
         new UsernamePasswordAuthenticationToken(principal, "pw", principal.getAuthorities());
     when(authenticationManager.authenticate(any())).thenReturn(authenticated);
-    when(jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN))).thenReturn("token-xyz");
 
-    LoginResponse response = authService.login(new LoginCredentials("alice", "pw"));
+    User user = new User();
+    user.setId(42L);
+    user.setUsername("alice");
+    user.addRole(Role.ADMIN);
+    when(userRepository.findByUsernameOrEmail("alice")).thenReturn(Optional.of(user));
+    when(jwtService.generateAccessToken(42L, "alice", user.getRoles(), 0)).thenReturn("access-xyz");
+    when(jwtService.generateRefreshToken(42L, "alice")).thenReturn("refresh-xyz");
 
-    assertEquals("token-xyz", response.token());
-    assertEquals(Set.of(Role.USER, Role.ADMIN), response.roles());
+    AuthTokens response = authService.login(new LoginCredentials("alice", "pw"));
+
+    assertEquals("access-xyz", response.accessToken());
+    assertEquals("refresh-xyz", response.refreshToken());
+    assertEquals(user.getRoles(), response.roles());
   }
 
   @Test
@@ -102,5 +113,76 @@ class AuthServiceTest {
 
     assertFalse(thrown.getMessage().contains(sensitivePrincipal));
     assertFalse(thrown.getMessage().contains(String.class.getName()));
+  }
+
+  @Test
+  void refreshIssuesNewTokensFromAValidRefreshToken() {
+    when(jwtService.parseToken("refresh-abc"))
+        .thenReturn(new JwtService.TokenData(42L, "alice", Set.of(), 0, TokenType.REFRESH));
+    User user = userEntity(42L, "alice");
+    when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+    when(jwtService.generateAccessToken(42L, "alice", user.getRoles(), 0)).thenReturn("new-access");
+    when(jwtService.generateRefreshToken(42L, "alice")).thenReturn("new-refresh");
+
+    AuthTokens response = authService.refresh("refresh-abc");
+
+    assertEquals("new-access", response.accessToken());
+    assertEquals("new-refresh", response.refreshToken());
+    assertEquals(user.getRoles(), response.roles());
+  }
+
+  @Test
+  void refreshRejectsAnAccessTokenPresentedAsRefreshToken() {
+    when(jwtService.parseToken("access-abc"))
+        .thenReturn(new JwtService.TokenData(42L, "alice", Set.of(Role.USER), 0, TokenType.ACCESS));
+
+    assertThrows(InvalidRefreshTokenException.class, () -> authService.refresh("access-abc"));
+  }
+
+  @Test
+  void refreshIgnoresTheRefreshTokensVersionAndMintsFromCurrentState() {
+    // A refresh token minted at an older version still works; the new tokens reflect the
+    // user's current state rather than the (possibly stale) claims in the refresh token.
+    when(jwtService.parseToken("stale"))
+        .thenReturn(new JwtService.TokenData(42L, "alice", Set.of(), 5, TokenType.REFRESH));
+    User user = userEntity(42L, "alice");
+    when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+    when(jwtService.generateAccessToken(42L, "alice", user.getRoles(), 0)).thenReturn("fresh");
+    when(jwtService.generateRefreshToken(42L, "alice")).thenReturn("fresh-refresh");
+
+    AuthTokens response = authService.refresh("stale");
+
+    assertEquals("fresh", response.accessToken());
+    assertEquals("fresh-refresh", response.refreshToken());
+  }
+
+  @Test
+  void refreshRejectsATokenForAnUnknownUser() {
+    when(jwtService.parseToken("orphan"))
+        .thenReturn(new JwtService.TokenData(99L, "ghost", Set.of(), 0, TokenType.REFRESH));
+    when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+    assertThrows(InvalidRefreshTokenException.class, () -> authService.refresh("orphan"));
+  }
+
+  @Test
+  void refreshRejectsAnUnparseableToken() {
+    when(jwtService.parseToken("garbage")).thenThrow(new MalformedJwtException("bad"));
+
+    assertThrows(InvalidRefreshTokenException.class, () -> authService.refresh("garbage"));
+  }
+
+  @Test
+  void refreshRejectsAMissingToken() {
+    assertThrows(InvalidRefreshTokenException.class, () -> authService.refresh(null));
+    assertThrows(InvalidRefreshTokenException.class, () -> authService.refresh("  "));
+  }
+
+  private static User userEntity(long id, String username) {
+    User user = new User();
+    user.setId(id);
+    user.setUsername(username);
+    user.addRole(Role.ADMIN);
+    return user;
   }
 }

--- a/src/test/java/ch/ethy/recipes/security/JWTFilterTest.java
+++ b/src/test/java/ch/ethy/recipes/security/JWTFilterTest.java
@@ -25,7 +25,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 @ExtendWith(MockitoExtension.class)
 class JWTFilterTest {
   @Mock private JwtService jwtService;
+  @Mock private TokenVersionService tokenVersionService;
   @InjectMocks private JWTFilter filter;
+
+  private static JwtService.TokenData accessToken(long userId, int version) {
+    return new JwtService.TokenData(userId, "alice", Set.of(Role.ADMIN), version, TokenType.ACCESS);
+  }
 
   @AfterEach
   void clearSecurityContext() {
@@ -34,8 +39,8 @@ class JWTFilterTest {
 
   @Test
   void populatesAuthoritiesFromTokenRoles() throws Exception {
-    when(jwtService.parseToken("opaque-token"))
-        .thenReturn(new JwtService.TokenData("alice", Set.of(Role.ADMIN)));
+    when(jwtService.parseToken("opaque-token")).thenReturn(accessToken(42L, 5));
+    when(tokenVersionService.getCurrentVersion(42L)).thenReturn(5);
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("Authorization", "Bearer opaque-token");
     MockHttpServletResponse response = new MockHttpServletResponse();
@@ -47,6 +52,38 @@ class JWTFilterTest {
     assertNotNull(auth);
     assertEquals("alice", ((UserDetails) auth.getPrincipal()).getUsername());
     assertTrue(auth.getAuthorities().contains(Role.ADMIN));
+  }
+
+  @Test
+  void rejectsAccessTokenWhoseVersionIsStale() throws Exception {
+    when(jwtService.parseToken("stale-token")).thenReturn(accessToken(42L, 5));
+    when(tokenVersionService.getCurrentVersion(42L)).thenReturn(6);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer stale-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertEquals(401, response.getStatus());
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+    assertNull(chain.getRequest());
+  }
+
+  @Test
+  void rejectsRefreshTokenPresentedAsAccessToken() throws Exception {
+    when(jwtService.parseToken("refresh-token"))
+        .thenReturn(new JwtService.TokenData(42L, "alice", Set.of(), 5, TokenType.REFRESH));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer refresh-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, response, chain);
+
+    assertEquals(401, response.getStatus());
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+    assertNull(chain.getRequest());
   }
 
   @Test

--- a/src/test/java/ch/ethy/recipes/security/JwtFailureAnalyzerTest.java
+++ b/src/test/java/ch/ethy/recipes/security/JwtFailureAnalyzerTest.java
@@ -27,14 +27,14 @@ class JwtFailureAnalyzerTest {
   @Test
   void describesTtlMisconfigurationAndMentionsIsoDuration() {
     JwtMisconfigurationException cause =
-        new JwtMisconfigurationException("jwt.ttl must be a positive duration");
+        new JwtMisconfigurationException("jwt.access-ttl must be a positive duration");
 
     FailureAnalysis analysis = analyzer.analyze(cause);
 
     assertNotNull(analysis);
-    assertEquals("jwt.ttl must be a positive duration", analysis.getDescription());
-    assertTrue(analysis.getAction().contains("JWT_TTL"));
-    assertTrue(analysis.getAction().contains("PT24H"));
+    assertEquals("jwt.access-ttl must be a positive duration", analysis.getDescription());
+    assertTrue(analysis.getAction().contains("JWT_ACCESS_TTL"));
+    assertTrue(analysis.getAction().contains("JWT_REFRESH_TTL"));
     assertTrue(analysis.getAction().contains("P30D"));
   }
 

--- a/src/test/java/ch/ethy/recipes/security/JwtServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/security/JwtServiceTest.java
@@ -2,6 +2,7 @@ package ch.ethy.recipes.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,30 +30,49 @@ class JwtServiceTest {
   private static final SecretKey SIGNING_KEY =
       new SecretKeySpec(Decoders.BASE64.decode(TEST_ENCODED_KEY), "HmacSHA256");
 
-  private static final Duration TEST_TTL = Duration.ofHours(1);
+  private static final Duration ACCESS_TTL = Duration.ofMinutes(15);
+  private static final Duration REFRESH_TTL = Duration.ofDays(7);
 
-  private final JwtService jwtService = new JwtService(TEST_ENCODED_KEY, TEST_TTL);
+  private final JwtService jwtService = new JwtService(TEST_ENCODED_KEY, ACCESS_TTL, REFRESH_TTL);
 
   @Test
-  void generateTokenEncodesUsername() {
-    String token = jwtService.generateToken("alice", Set.of());
+  void accessTokenCarriesUserIdUsernameRolesAndVersion() {
+    String token = jwtService.generateAccessToken(42L, "alice", Set.of(Role.USER, Role.ADMIN), 3);
 
-    assertEquals("alice", jwtService.parseToken(token).username());
+    JwtService.TokenData data = jwtService.parseToken(token);
+    assertEquals(42L, data.userId());
+    assertEquals("alice", data.username());
+    assertEquals(Set.of(Role.USER, Role.ADMIN), data.roles());
+    assertEquals(3, data.version());
+    assertEquals(TokenType.ACCESS, data.type());
   }
 
   @Test
-  void generateTokenEncodesRoles() {
-    String token = jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN));
+  void refreshTokenCarriesNoRolesAndIsTypedRefresh() {
+    String token = jwtService.generateRefreshToken(42L, "alice");
 
-    assertEquals(Set.of(Role.USER, Role.ADMIN), jwtService.parseToken(token).roles());
+    JwtService.TokenData data = jwtService.parseToken(token);
+    assertEquals(42L, data.userId());
+    assertEquals("alice", data.username());
+    assertTrue(data.roles().isEmpty());
+    assertEquals(TokenType.REFRESH, data.type());
   }
 
   @Test
-  void generateTokenSerializesRolesAsEnumNameStrings() {
-    // Pins the JWT wire format: the 'roles' claim is a JSON array of Role.name() strings
-    // (e.g. "USER", "ADMIN"), not getAuthority() values ("ROLE_USER", ...). A rename of a
-    // Role constant changes the token payload and must break this test loudly.
-    String token = jwtService.generateToken("alice", Set.of(Role.USER, Role.ADMIN));
+  void refreshTokenOmitsRolesAndVersionClaims() {
+    // The refresh path re-reads the user from the DB, so neither claim is read off the token;
+    // omitting them keeps the wire format honest about what is actually trusted.
+    String token = jwtService.generateRefreshToken(42L, "alice");
+
+    Claims claims = claimsOf(token);
+    assertNull(claims.get("roles"));
+    assertNull(claims.get("ver"));
+  }
+
+  @Test
+  void accessTokenSerializesRolesAsEnumNameStrings() {
+    // Pins the JWT wire format: 'roles' is a JSON array of Role.name() strings, not authorities.
+    String token = jwtService.generateAccessToken(1L, "alice", Set.of(Role.USER, Role.ADMIN), 0);
 
     List<?> rolesClaim =
         Jwts.parser()
@@ -66,45 +86,89 @@ class JwtServiceTest {
   }
 
   @Test
-  void parseTokenReturnsEmptyRolesWhenNoneEncoded() {
-    String token = jwtService.generateToken("alice", Set.of());
-
-    assertTrue(jwtService.parseToken(token).roles().isEmpty());
-  }
-
-  @Test
   void parseTokenIgnoresUnknownRoleStrings() {
     String tokenWithBogusRole =
-        Jwts.builder()
-            .subject("User Details")
-            .claim("usernameOrEmail", "alice")
-            .claim("roles", Arrays.asList("USER", "SUPERUSER", "ADMIN", null))
-            .issuer("recipes")
-            .expiration(Date.from(Instant.now().plus(TEST_TTL)))
-            .signWith(SIGNING_KEY)
-            .compact();
+        baseToken().claim("roles", Arrays.asList("USER", "X", null)).compact();
 
-    assertEquals(Set.of(Role.USER, Role.ADMIN), jwtService.parseToken(tokenWithBogusRole).roles());
+    assertEquals(Set.of(Role.USER), jwtService.parseToken(tokenWithBogusRole).roles());
   }
 
   @Test
   void parseTokenRejectsTokenMissingUsernameClaim() {
-    String tokenMissingUsername =
+    String token =
         Jwts.builder()
             .subject("User Details")
-            .claim("roles", List.of("USER"))
+            .claim("uid", 1L)
+            .claim("ver", 0)
+            .claim("type", "ACCESS")
             .issuer("recipes")
-            .expiration(Date.from(Instant.now().plus(TEST_TTL)))
+            .expiration(Date.from(Instant.now().plus(ACCESS_TTL)))
             .signWith(SIGNING_KEY)
             .compact();
 
-    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(tokenMissingUsername));
+    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(token));
+  }
+
+  @Test
+  void parseTokenRejectsTokenMissingUserId() {
+    String token =
+        Jwts.builder()
+            .subject("User Details")
+            .claim("usernameOrEmail", "alice")
+            .claim("ver", 0)
+            .claim("type", "ACCESS")
+            .issuer("recipes")
+            .expiration(Date.from(Instant.now().plus(ACCESS_TTL)))
+            .signWith(SIGNING_KEY)
+            .compact();
+
+    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(token));
+  }
+
+  @Test
+  void parseTokenRejectsTokenMissingVersion() {
+    String token =
+        Jwts.builder()
+            .subject("User Details")
+            .claim("uid", 1L)
+            .claim("usernameOrEmail", "alice")
+            .claim("type", "ACCESS")
+            .issuer("recipes")
+            .expiration(Date.from(Instant.now().plus(ACCESS_TTL)))
+            .signWith(SIGNING_KEY)
+            .compact();
+
+    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(token));
+  }
+
+  @Test
+  void parseTokenRejectsTokenMissingType() {
+    String token =
+        Jwts.builder()
+            .subject("User Details")
+            .claim("uid", 1L)
+            .claim("usernameOrEmail", "alice")
+            .claim("ver", 0)
+            .issuer("recipes")
+            .expiration(Date.from(Instant.now().plus(ACCESS_TTL)))
+            .signWith(SIGNING_KEY)
+            .compact();
+
+    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(token));
+  }
+
+  @Test
+  void parseTokenRejectsUnknownType() {
+    String token = baseToken().claim("type", "BOGUS").compact();
+
+    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(token));
   }
 
   @Test
   void constructorRejectsMissingSecret() {
     JwtMisconfigurationException thrown =
-        assertThrows(JwtMisconfigurationException.class, () -> new JwtService("", TEST_TTL));
+        assertThrows(
+            JwtMisconfigurationException.class, () -> new JwtService("", ACCESS_TTL, REFRESH_TTL));
 
     assertTrue(thrown.getMessage().toLowerCase().contains("jwt.secret"));
     assertTrue(thrown.getMessage().toLowerCase().contains("jwt_secret"));
@@ -115,7 +179,9 @@ class JwtServiceTest {
     String shortKey = Base64.getEncoder().encodeToString(new byte[16]);
 
     JwtMisconfigurationException thrown =
-        assertThrows(JwtMisconfigurationException.class, () -> new JwtService(shortKey, TEST_TTL));
+        assertThrows(
+            JwtMisconfigurationException.class,
+            () -> new JwtService(shortKey, ACCESS_TTL, REFRESH_TTL));
 
     assertTrue(thrown.getMessage().contains("32 bytes"));
   }
@@ -124,101 +190,124 @@ class JwtServiceTest {
   void constructorRejectsInvalidBase64() {
     assertThrows(
         JwtMisconfigurationException.class,
-        () -> new JwtService("not valid base64 !@#$", TEST_TTL));
+        () -> new JwtService("not valid base64 !@#$", ACCESS_TTL, REFRESH_TTL));
   }
 
   @Test
-  void constructorRejectsZeroTtl() {
+  void constructorRejectsNonPositiveAccessTtl() {
     JwtMisconfigurationException thrown =
         assertThrows(
             JwtMisconfigurationException.class,
-            () -> new JwtService(TEST_ENCODED_KEY, Duration.ZERO));
+            () -> new JwtService(TEST_ENCODED_KEY, Duration.ZERO, REFRESH_TTL));
 
-    assertTrue(thrown.getMessage().toLowerCase().contains("jwt.ttl"));
+    assertTrue(thrown.getMessage().toLowerCase().contains("access"));
   }
 
   @Test
-  void constructorRejectsNegativeTtl() {
-    assertThrows(
-        JwtMisconfigurationException.class,
-        () -> new JwtService(TEST_ENCODED_KEY, Duration.ofSeconds(-1)));
-  }
-
-  @Test
-  void constructorRejectsTtlAboveCeiling() {
+  void constructorRejectsNonPositiveRefreshTtl() {
     JwtMisconfigurationException thrown =
         assertThrows(
             JwtMisconfigurationException.class,
-            () -> new JwtService(TEST_ENCODED_KEY, Duration.ofDays(31)));
+            () -> new JwtService(TEST_ENCODED_KEY, ACCESS_TTL, Duration.ofSeconds(-1)));
 
-    assertTrue(thrown.getMessage().toLowerCase().contains("jwt.ttl"));
+    assertTrue(thrown.getMessage().toLowerCase().contains("refresh"));
+  }
+
+  @Test
+  void constructorRejectsAccessTtlAboveCeiling() {
+    JwtMisconfigurationException thrown =
+        assertThrows(
+            JwtMisconfigurationException.class,
+            () -> new JwtService(TEST_ENCODED_KEY, Duration.ofDays(31), REFRESH_TTL));
+
     assertTrue(thrown.getMessage().contains("P30D"));
   }
 
   @Test
-  void constructorAcceptsTtlAtCeiling() {
-    new JwtService(TEST_ENCODED_KEY, Duration.ofDays(30));
+  void constructorRejectsRefreshTtlAboveCeiling() {
+    JwtMisconfigurationException thrown =
+        assertThrows(
+            JwtMisconfigurationException.class,
+            () -> new JwtService(TEST_ENCODED_KEY, ACCESS_TTL, Duration.ofDays(31)));
+
+    assertTrue(thrown.getMessage().contains("P30D"));
   }
 
   @Test
-  void generateTokenSetsExpClaimInFuture() {
+  void constructorAcceptsRefreshTtlAtCeiling() {
+    new JwtService(TEST_ENCODED_KEY, ACCESS_TTL, Duration.ofDays(30));
+  }
+
+  @Test
+  void accessTokenExpiresByAccessTtl() {
     Instant before = Instant.now();
-    String token = jwtService.generateToken("alice", Set.of());
+    String token = jwtService.generateAccessToken(1L, "alice", Set.of(), 0);
     Instant after = Instant.now();
 
-    Claims claims =
-        Jwts.parser().verifyWith(SIGNING_KEY).build().parseSignedClaims(token).getPayload();
-    Date exp = claims.getExpiration();
+    Date exp = claimsOf(token).getExpiration();
     assertNotNull(exp);
-    // exp should fall in [before+TTL, after+TTL]
     Instant expInstant = exp.toInstant();
-    assertTrue(
-        !expInstant.isBefore(before.plus(TEST_TTL).minusSeconds(1)),
-        "exp " + expInstant + " is earlier than before+TTL " + before.plus(TEST_TTL));
-    assertTrue(
-        !expInstant.isAfter(after.plus(TEST_TTL).plusSeconds(1)),
-        "exp " + expInstant + " is later than after+TTL " + after.plus(TEST_TTL));
+    assertTrue(!expInstant.isBefore(before.plus(ACCESS_TTL).minusSeconds(1)));
+    assertTrue(!expInstant.isAfter(after.plus(ACCESS_TTL).plusSeconds(1)));
+  }
+
+  @Test
+  void refreshTokenExpiresByRefreshTtl() {
+    Instant before = Instant.now();
+    String token = jwtService.generateRefreshToken(1L, "alice");
+    Instant after = Instant.now();
+
+    Date exp = claimsOf(token).getExpiration();
+    assertNotNull(exp);
+    Instant expInstant = exp.toInstant();
+    assertTrue(!expInstant.isBefore(before.plus(REFRESH_TTL).minusSeconds(1)));
+    assertTrue(!expInstant.isAfter(after.plus(REFRESH_TTL).plusSeconds(1)));
   }
 
   @Test
   void parseTokenRejectsExpiredToken() {
-    String expired =
-        Jwts.builder()
-            .subject("User Details")
-            .claim("usernameOrEmail", "alice")
-            .issuer("recipes")
-            .expiration(Date.from(Instant.now().minusSeconds(60)))
-            .signWith(SIGNING_KEY)
-            .compact();
+    String expired = baseToken().expiration(Date.from(Instant.now().minusSeconds(60))).compact();
 
     assertThrows(ExpiredJwtException.class, () -> jwtService.parseToken(expired));
   }
 
   @Test
   void parseTokenRejectsTokenWithoutExpClaim() {
-    String tokenWithoutExp =
+    String token =
         Jwts.builder()
             .subject("User Details")
+            .claim("uid", 1L)
             .claim("usernameOrEmail", "alice")
+            .claim("ver", 0)
+            .claim("type", "ACCESS")
             .issuer("recipes")
             .signWith(SIGNING_KEY)
             .compact();
 
-    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(tokenWithoutExp));
+    assertThrows(MalformedJwtException.class, () -> jwtService.parseToken(token));
   }
 
   @Test
   void parseTokenRejectsTokenWithWrongSubject() {
-    String tampered =
-        Jwts.builder()
-            .subject("Not User Details")
-            .claim("usernameOrEmail", "alice")
-            .issuer("recipes")
-            .expiration(Date.from(Instant.now().plus(TEST_TTL)))
-            .signWith(SIGNING_KEY)
-            .compact();
+    String tampered = baseToken().subject("Not User Details").compact();
 
     assertThrows(
         io.jsonwebtoken.IncorrectClaimException.class, () -> jwtService.parseToken(tampered));
+  }
+
+  private static io.jsonwebtoken.JwtBuilder baseToken() {
+    return Jwts.builder()
+        .subject("User Details")
+        .claim("uid", 1L)
+        .claim("usernameOrEmail", "alice")
+        .claim("ver", 0)
+        .claim("type", "ACCESS")
+        .issuer("recipes")
+        .expiration(Date.from(Instant.now().plus(ACCESS_TTL)))
+        .signWith(SIGNING_KEY);
+  }
+
+  private static Claims claimsOf(String token) {
+    return Jwts.parser().verifyWith(SIGNING_KEY).build().parseSignedClaims(token).getPayload();
   }
 }

--- a/src/test/java/ch/ethy/recipes/security/RefreshTokenCookieFactoryTest.java
+++ b/src/test/java/ch/ethy/recipes/security/RefreshTokenCookieFactoryTest.java
@@ -1,0 +1,45 @@
+package ch.ethy.recipes.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+class RefreshTokenCookieFactoryTest {
+  private final RefreshTokenCookieFactory factory =
+      new RefreshTokenCookieFactory(Duration.ofDays(7), true);
+
+  @Test
+  void issueProducesAnHttpOnlySecureStrictCookieScopedToAuth() {
+    ResponseCookie c = factory.issue("the-token");
+
+    assertEquals("refreshToken", c.getName());
+    assertEquals("the-token", c.getValue());
+    assertTrue(c.isHttpOnly());
+    assertTrue(c.isSecure());
+    assertEquals("Strict", c.getSameSite());
+    assertEquals("/api/auth", c.getPath());
+    assertEquals(Duration.ofDays(7), c.getMaxAge());
+  }
+
+  @Test
+  void clearProducesAnImmediatelyExpiredCookieWithTheSameAttributes() {
+    ResponseCookie c = factory.clear();
+
+    assertEquals("refreshToken", c.getName());
+    assertEquals("", c.getValue());
+    assertEquals(Duration.ZERO, c.getMaxAge());
+    assertTrue(c.isHttpOnly());
+    assertEquals("/api/auth", c.getPath());
+  }
+
+  @Test
+  void secureFlagFollowsConfiguration() {
+    ResponseCookie insecure = new RefreshTokenCookieFactory(Duration.ofDays(7), false).issue("t");
+
+    assertFalse(insecure.isSecure());
+  }
+}

--- a/src/test/java/ch/ethy/recipes/security/RoleRevocationTest.java
+++ b/src/test/java/ch/ethy/recipes/security/RoleRevocationTest.java
@@ -1,0 +1,116 @@
+package ch.ethy.recipes.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import ch.ethy.recipes.user.Role;
+import ch.ethy.recipes.user.User;
+import ch.ethy.recipes.user.UserRepository;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Regression test pinning the bounded role-revocation guarantee (#145): once a user's tokens are
+ * revoked (token version bumped), their outstanding access token stops authenticating, and the next
+ * refresh hands back a token carrying the user's current — reduced — role.
+ */
+@ExtendWith(MockitoExtension.class)
+class RoleRevocationTest {
+  private static final String TEST_ENCODED_KEY =
+      "sPYf4F91EbSV6mfc+ZoqZhVuZih8mTiyx1jjPCq8qeuBaCnOlpq8gm3XwFPFo8Sj";
+
+  @Mock private UserRepository userRepository;
+  @Mock private AuthenticationManager authenticationManager;
+  @Mock private PasswordEncoder passwordEncoder;
+
+  private final JwtService jwtService =
+      new JwtService(TEST_ENCODED_KEY, Duration.ofMinutes(15), Duration.ofDays(7));
+  private TokenVersionService tokenVersionService;
+  private JWTFilter filter;
+  private AuthService authService;
+
+  @BeforeEach
+  void setUp() {
+    tokenVersionService = new TokenVersionService(userRepository);
+    filter = new JWTFilter(jwtService, tokenVersionService);
+    authService =
+        new AuthService(authenticationManager, jwtService, passwordEncoder, userRepository);
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void demotionRejectsTheStaleAccessTokenAndRefreshDowngradesTheSession() throws Exception {
+    // Given an admin holding tokens minted at version 0.
+    when(userRepository.findTokenVersionById(42L)).thenReturn(Optional.of(0));
+    String accessToken =
+        jwtService.generateAccessToken(42L, "alice", Set.of(Role.USER, Role.ADMIN), 0);
+    String refreshToken = jwtService.generateRefreshToken(42L, "alice");
+
+    Authentication asAdmin = authenticate(accessToken);
+    assertNotNull(asAdmin);
+    assertTrue(asAdmin.getAuthorities().contains(Role.ADMIN));
+
+    // When the user is demoted to USER and their tokens are revoked (version -> 1).
+    User demoted = new User();
+    demoted.setId(42L);
+    demoted.setUsername("alice");
+    ReflectionTestUtils.setField(demoted, "tokenVersion", 1);
+    when(userRepository.findById(42L)).thenReturn(Optional.of(demoted));
+    when(userRepository.findTokenVersionById(42L)).thenReturn(Optional.of(1));
+    when(userRepository.incrementTokenVersion(42L)).thenReturn(1);
+    tokenVersionService.revokeTokens(42L);
+
+    // Then the stale access token no longer authenticates.
+    MockHttpServletResponse rejected = runFilter(accessToken);
+    assertEquals(401, rejected.getStatus());
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+
+    // And refreshing yields a usable access token carrying only the reduced role.
+    AuthTokens refreshed = authService.refresh(refreshToken);
+    JwtService.TokenData newAccess = jwtService.parseToken(refreshed.accessToken());
+    assertEquals(Set.of(Role.USER), newAccess.roles());
+    assertEquals(1, newAccess.version());
+
+    Authentication asUser = authenticate(refreshed.accessToken());
+    assertNotNull(asUser);
+    assertTrue(asUser.getAuthorities().contains(Role.USER));
+    assertFalse(asUser.getAuthorities().contains(Role.ADMIN));
+  }
+
+  private Authentication authenticate(String token) throws Exception {
+    runFilter(token);
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+
+  private MockHttpServletResponse runFilter(String token) throws Exception {
+    SecurityContextHolder.clearContext();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + token);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(request, response, new MockFilterChain());
+    return response;
+  }
+}

--- a/src/test/java/ch/ethy/recipes/security/TokenVersionServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/security/TokenVersionServiceTest.java
@@ -1,0 +1,71 @@
+package ch.ethy.recipes.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.ethy.recipes.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenVersionServiceTest {
+  @Mock private UserRepository userRepository;
+
+  private TokenVersionService newService() {
+    return new TokenVersionService(userRepository);
+  }
+
+  @Test
+  void getCurrentVersionReturnsTheStoredVersion() {
+    when(userRepository.findTokenVersionById(1L)).thenReturn(Optional.of(7));
+
+    assertEquals(7, newService().getCurrentVersion(1L));
+  }
+
+  @Test
+  void getCurrentVersionCachesAcrossCallsToAvoidRepeatedLookups() {
+    when(userRepository.findTokenVersionById(1L)).thenReturn(Optional.of(7));
+    TokenVersionService service = newService();
+
+    assertEquals(7, service.getCurrentVersion(1L));
+    assertEquals(7, service.getCurrentVersion(1L));
+
+    verify(userRepository, times(1)).findTokenVersionById(1L);
+  }
+
+  @Test
+  void revokeTokensIncrementsInTheDatabaseAndInvalidatesTheCachedEntry() {
+    when(userRepository.findTokenVersionById(1L)).thenReturn(Optional.of(7), Optional.of(8));
+    when(userRepository.incrementTokenVersion(1L)).thenReturn(1);
+    TokenVersionService service = newService();
+
+    assertEquals(7, service.getCurrentVersion(1L));
+    service.revokeTokens(1L);
+    assertEquals(8, service.getCurrentVersion(1L));
+
+    verify(userRepository, times(1)).incrementTokenVersion(1L);
+    verify(userRepository, times(2)).findTokenVersionById(1L);
+  }
+
+  @Test
+  void getCurrentVersionRejectsAnUnknownUser() {
+    when(userRepository.findTokenVersionById(99L)).thenReturn(Optional.empty());
+    TokenVersionService service = newService();
+
+    assertThrows(UnknownUserException.class, () -> service.getCurrentVersion(99L));
+  }
+
+  @Test
+  void revokeTokensRejectsAnUnknownUser() {
+    when(userRepository.incrementTokenVersion(99L)).thenReturn(0);
+    TokenVersionService service = newService();
+
+    assertThrows(UnknownUserException.class, () -> service.revokeTokens(99L));
+  }
+}

--- a/src/test/java/ch/ethy/recipes/user/UserControllerSecurityTest.java
+++ b/src/test/java/ch/ethy/recipes/user/UserControllerSecurityTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import ch.ethy.recipes.security.JwtService;
+import ch.ethy.recipes.security.TokenVersionService;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,10 +49,11 @@ class UserControllerSecurityTest {
   @MockitoBean private UserService userService;
 
   // JWTFilter is pulled into the @WebMvcTest slice as a servlet filter and
-  // declares a JwtService dependency. We use @WithMockUser to set the security
-  // context directly, so the real JWT path is not exercised here — mocking
-  // the dependency keeps the slice context wireable.
+  // declares JwtService and TokenVersionService dependencies. We use
+  // @WithMockUser to set the security context directly, so the real JWT path is
+  // not exercised here — mocking the dependencies keeps the slice context wireable.
   @MockitoBean private JwtService jwtService;
+  @MockitoBean private TokenVersionService tokenVersionService;
 
   @BeforeEach
   void stubExistingUser() {


### PR DESCRIPTION
## Summary
- Split JWTs into a short-lived **access token** (`JWT_ACCESS_TTL`, default `PT15M`) and a longer-lived **refresh token** (`JWT_REFRESH_TTL`, default `P7D`), replacing the single `JWT_TTL`. Every token carries the user id, a token type, and the user's token version.
- New `users.token_version` column is the revocation primitive. `JWTFilter` authenticates only an ACCESS token whose version still matches the user's current version, read through a short-lived Caffeine cache — bumping the version revokes outstanding access tokens within a bounded window, per-user and multi-instance-safe (the DB is the source of truth).
- `POST /api/auth/refresh` exchanges a refresh token for a fresh pair, re-reading the user so a mid-session role change is reflected in the next access token. Refresh is intentionally **not** version-gated: a demotion downgrades the session on the next refresh rather than forcing an immediate re-login.
- Frontend: `AuthService` stores/refreshes the tokens and a `refreshInterceptor` refreshes once on a `401` for a protected request, retries with the new token, and logs out on refresh failure.
- Regression test (#145) drives the whole guarantee end to end: revoke + demote → stale access token rejected → refresh yields a usable, downgraded token.

## Notes / deferred
- There is no login form yet, so the full login→refresh cycle isn't browser-demoable; the frontend refresh machinery is unit-tested and will be wired to the login UI in the login slice.
- Killing a refresh token outright (full forced logout) is out of scope here; cross-instance sub-second invalidation is tracked in #173.

## Test plan
- [x] `./mvnw test` — 54 backend tests + frontend suite green
- [ ] After deploy: `POST /api/auth/login` returns `{ token, refreshToken, roles }`; an expired access token triggers a transparent refresh + retry; a role change downgrades the session on the next refresh.

Closes #143
Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)