### PR TITLE
feat(security): login form + AuthService.login() with credential validation

### DIFF
--- a/docs/arc42/06-runtime-view.md
+++ b/docs/arc42/06-runtime-view.md
@@ -14,7 +14,8 @@ Browser                  AuthController      AuthService       JwtService       
 ```
 
 The access token is returned in the body; the refresh token is delivered out-of-band as an
-`HttpOnly` cookie, so it is never readable by JavaScript.
+`HttpOnly` cookie, so it is never readable by JavaScript. Invalid credentials yield 401; a request
+missing or blanking either field is rejected with 400 before authentication is attempted.
 
 ## 6.2 Token Refresh
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webmvc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/ch/ethy/recipes/security/AuthController.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthController.java
@@ -1,6 +1,7 @@
 package ch.ethy.recipes.security;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import java.util.Map;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -27,7 +28,7 @@ public class AuthController {
 
   @PostMapping("/login")
   public LoginResponse login(
-      @RequestBody LoginCredentials credentials, HttpServletResponse response) {
+      @RequestBody @Valid LoginCredentials credentials, HttpServletResponse response) {
     try {
       return respondWithTokens(authService.login(credentials), response);
     } catch (AuthenticationException e) {

--- a/src/main/java/ch/ethy/recipes/security/LoginCredentials.java
+++ b/src/main/java/ch/ethy/recipes/security/LoginCredentials.java
@@ -1,3 +1,8 @@
 package ch.ethy.recipes.security;
 
-public record LoginCredentials(String usernameOrEmail, String password) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LoginCredentials(
+    @NotBlank @Size(max = 256) String usernameOrEmail,
+    @NotBlank @Size(max = 256) String password) {}

--- a/src/main/webapp/app/security/auth.service.spec.ts
+++ b/src/main/webapp/app/security/auth.service.spec.ts
@@ -13,7 +13,7 @@ describe('AuthService', () => {
   let routerSpy: Mocked<Pick<Router, 'navigate'>>;
 
   beforeEach(() => {
-    routerSpy = { navigate: vi.fn() };
+    routerSpy = { navigate: vi.fn().mockResolvedValue(true) };
 
     TestBed.configureTestingModule({
       providers: [
@@ -60,6 +60,40 @@ describe('AuthService', () => {
     const third = firstValueFrom(service.refresh());
     httpMock.expectOne('/api/auth/refresh').flush({ token: 'again', roles: ['USER'] });
     expect(await third).toBe('again');
+  });
+
+  it('login sends credentials, holds the access token in memory, and routes to the landing page', async () => {
+    const promise = service.login({ usernameOrEmail: 'alice', password: 'pw' });
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.withCredentials).toBe(true);
+    expect(req.request.body).toEqual({ usernameOrEmail: 'alice', password: 'pw' });
+    req.flush({ token: 'access-1', roles: ['USER'] });
+
+    expect(await promise).toBe(true);
+    expect(service.getAccessToken()).toBe('access-1');
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('login returns false on invalid credentials without storing a token or navigating', async () => {
+    const promise = service.login({ usernameOrEmail: 'alice', password: 'wrong' });
+
+    httpMock.expectOne('/api/auth/login').flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    expect(await promise).toBe(false);
+    expect(service.getAccessToken()).toBeNull();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it('login propagates non-401 errors instead of swallowing them', async () => {
+    const promise = service.login({ usernameOrEmail: 'alice', password: 'pw' });
+
+    httpMock.expectOne('/api/auth/login').flush(null, { status: 500, statusText: 'Server Error' });
+
+    await expect(promise).rejects.toBeTruthy();
+    expect(service.getAccessToken()).toBeNull();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
   });
 
   it('logout clears the in-memory token, asks the backend to drop the cookie, and routes to login', () => {

--- a/src/main/webapp/app/security/auth.service.ts
+++ b/src/main/webapp/app/security/auth.service.ts
@@ -9,6 +9,7 @@ import {
   of,
   shareReplay,
   switchMap,
+  tap,
 } from 'rxjs';
 import { Router } from '@angular/router';
 
@@ -20,6 +21,11 @@ export interface RegistrationDetails {
 
 export interface DuplicateUserError {
   conflictingFields: string[];
+}
+
+export interface LoginCredentials {
+  usernameOrEmail: string;
+  password: string;
 }
 
 export interface LoginResponse {
@@ -51,6 +57,26 @@ export class AuthService {
         catchError((error: HttpErrorResponse) => {
           if (error.status === 409) {
             return of(error.error as DuplicateUserError);
+          }
+          throw error;
+        }),
+      ),
+    );
+  }
+
+  // Resolves true on success (token stored, routed to the landing page) and false on invalid
+  // credentials (401) so the form can show an inline error. Other failures propagate.
+  async login(credentials: LoginCredentials): Promise<boolean> {
+    return firstValueFrom(
+      this.http.post<LoginResponse>('/api/auth/login', credentials, { withCredentials: true }).pipe(
+        tap((response) => (this.accessToken = response.token)),
+        switchMap(() => this.router.navigate(['/'])),
+        // Resolve a definite "auth succeeded" rather than navigate()'s result, so a navigation
+        // hiccup can't masquerade as bad credentials.
+        map(() => true),
+        catchError((error: HttpErrorResponse) => {
+          if (error.status === 401) {
+            return of(false);
           }
           throw error;
         }),

--- a/src/main/webapp/app/security/login/login.html
+++ b/src/main/webapp/app/security/login/login.html
@@ -1,0 +1,44 @@
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Login</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <form [formRoot]="loginForm">
+      <mat-form-field>
+        <mat-label>Benutzername oder Email</mat-label>
+        <input
+          matInput
+          type="text"
+          autocomplete="username"
+          [formField]="loginForm.usernameOrEmail"
+        />
+        @if (
+          loginForm.usernameOrEmail().touched() && loginForm.usernameOrEmail().errors().length > 0
+        ) {
+          <mat-error>{{ loginForm.usernameOrEmail().errors()[0].message }}</mat-error>
+        }
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Passwort</mat-label>
+        <input
+          matInput
+          type="password"
+          autocomplete="current-password"
+          [formField]="loginForm.password"
+        />
+        @if (loginForm.password().touched() && loginForm.password().errors().length > 0) {
+          <mat-error>{{ loginForm.password().errors()[0].message }}</mat-error>
+        }
+      </mat-form-field>
+      @if (loginFailed()) {
+        <p class="login-error" data-test-id="loginError">Ungültige Anmeldedaten</p>
+      }
+      <div class="submit-row">
+        @if (loginForm().submitting()) {
+          <mat-spinner diameter="20"></mat-spinner>
+        }
+        <button mat-flat-button type="submit" [disabled]="loginForm().submitting()">Login</button>
+      </div>
+    </form>
+  </mat-card-content>
+</mat-card>

--- a/src/main/webapp/app/security/login/login.scss
+++ b/src/main/webapp/app/security/login/login.scss
@@ -1,0 +1,28 @@
+mat-card {
+  margin: 0 auto;
+  max-width: 800px;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-top: 1rem;
+  gap: 0.75rem;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+.login-error {
+  align-self: flex-start;
+  margin: 0;
+  color: var(--mat-sys-error);
+}
+
+.submit-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/src/main/webapp/app/security/login/login.spec.ts
+++ b/src/main/webapp/app/security/login/login.spec.ts
@@ -1,14 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Mocked } from 'vitest';
+import { AuthService } from '../auth.service';
 
 import { Login } from './login';
 
 describe('Login', () => {
   let component: Login;
   let fixture: ComponentFixture<Login>;
+  let authServiceSpy: Mocked<Pick<AuthService, 'login'>>;
 
   beforeEach(async () => {
+    authServiceSpy = { login: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [Login],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Login);
@@ -18,5 +24,133 @@ describe('Login', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should require both fields', () => {
+    const form = component.loginForm;
+    expect(form.usernameOrEmail().errors().length).toBeGreaterThan(0);
+    expect(form.password().errors().length).toBeGreaterThan(0);
+  });
+
+  it('caps both fields at 256 characters in the DOM, mirroring the backend', () => {
+    const inputs: HTMLInputElement[] = Array.from(fixture.nativeElement.querySelectorAll('input'));
+    expect(inputs.length).toBe(2);
+    inputs.forEach((input) => expect(input.maxLength).toBe(256));
+  });
+
+  it('rejects a value over 256 characters set through the model, not just typed', () => {
+    component.loginModel.set({ usernameOrEmail: 'a'.repeat(257), password: 'b'.repeat(257) });
+    TestBed.flushEffects();
+
+    expect(component.loginForm.usernameOrEmail().errors().length).toBeGreaterThan(0);
+    expect(component.loginForm.password().errors().length).toBeGreaterThan(0);
+    expect(component.loginForm().valid()).toBe(false);
+  });
+
+  it('should be valid when both fields are filled', () => {
+    component.loginModel.set({ usernameOrEmail: 'alice', password: 'pw' });
+    TestBed.flushEffects();
+    expect(component.loginForm().valid()).toBe(true);
+  });
+
+  it('should show error messages for empty required fields', () => {
+    component.loginForm.usernameOrEmail().markAsTouched();
+    component.loginForm.password().markAsTouched();
+    fixture.detectChanges();
+
+    const errorElements = fixture.nativeElement.querySelectorAll('mat-error');
+    expect(errorElements.length).toBe(2);
+    expect(errorElements[0].textContent).toContain('Benutzername oder Email ist erforderlich');
+    expect(errorElements[1].textContent).toContain('Passwort ist erforderlich');
+  });
+
+  it('should submit credentials to the auth service', async () => {
+    authServiceSpy.login.mockResolvedValue(true);
+
+    component.loginModel.set({ usernameOrEmail: 'alice', password: 'pw' });
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('button[type="submit"]').click();
+    await new Promise((r) => setTimeout(r));
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    expect(authServiceSpy.login).toHaveBeenCalledWith({ usernameOrEmail: 'alice', password: 'pw' });
+    expect(fixture.nativeElement.querySelector('[data-test-id="loginError"]')).toBeNull();
+  });
+
+  it('should show an error message when credentials are rejected', async () => {
+    authServiceSpy.login.mockResolvedValue(false);
+
+    component.loginModel.set({ usernameOrEmail: 'alice', password: 'wrong' });
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('button[type="submit"]').click();
+    await new Promise((r) => setTimeout(r));
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('[data-test-id="loginError"]');
+    expect(error).toBeTruthy();
+    expect(error.textContent).toContain('Ungültige Anmeldedaten');
+  });
+
+  it('should hide the rejected-credentials error once the user edits a field', async () => {
+    authServiceSpy.login.mockResolvedValue(false);
+
+    component.loginModel.set({ usernameOrEmail: 'alice', password: 'wrong' });
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('button[type="submit"]').click();
+    await new Promise((r) => setTimeout(r));
+    TestBed.flushEffects();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-test-id="loginError"]')).toBeTruthy();
+
+    // The user starts correcting their password.
+    component.loginModel.set({ usernameOrEmail: 'alice', password: 'corrected' });
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-test-id="loginError"]')).toBeNull();
+  });
+
+  it('should disable fields and button and show spinner during submission', async () => {
+    let resolveLogin!: () => void;
+    authServiceSpy.login.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveLogin = () => resolve(true);
+      }),
+    );
+
+    component.loginModel.set({ usernameOrEmail: 'alice', password: 'pw' });
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    const submitButton: HTMLButtonElement =
+      fixture.nativeElement.querySelector('button[type="submit"]');
+    submitButton.click();
+    fixture.detectChanges();
+
+    const inputs = fixture.nativeElement.querySelectorAll('input');
+    inputs.forEach((input: HTMLInputElement) => {
+      expect(input.disabled).toBe(true);
+    });
+    expect(submitButton.disabled).toBe(true);
+    expect(fixture.nativeElement.querySelector('mat-spinner')).toBeTruthy();
+
+    resolveLogin();
+    await new Promise((r) => setTimeout(r));
+    TestBed.flushEffects();
+    fixture.detectChanges();
+
+    inputs.forEach((input: HTMLInputElement) => {
+      expect(input.disabled).toBe(false);
+    });
+    expect(submitButton.disabled).toBe(false);
+    expect(fixture.nativeElement.querySelector('mat-spinner')).toBeNull();
   });
 });

--- a/src/main/webapp/app/security/login/login.ts
+++ b/src/main/webapp/app/security/login/login.ts
@@ -1,9 +1,92 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
+import { MatCard, MatCardContent, MatCardHeader, MatCardTitle } from '@angular/material/card';
+import { MatError, MatFormField, MatInput, MatLabel } from '@angular/material/input';
+import { disabled, form, FormField, FormRoot, maxLength, required } from '@angular/forms/signals';
+import { MatButton } from '@angular/material/button';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-login',
-  imports: [],
+  imports: [
+    MatCardContent,
+    MatCardTitle,
+    MatCardHeader,
+    MatCard,
+    MatError,
+    MatFormField,
+    MatInput,
+    FormField,
+    FormRoot,
+    MatLabel,
+    MatButton,
+    MatProgressSpinner,
+  ],
   templateUrl: './login.html',
   styleUrl: './login.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Login {}
+export class Login {
+  private authService = inject(AuthService);
+
+  // Mirrors the backend @Size cap on LoginCredentials so an over-long value can never be submitted,
+  // however it reaches the model (typing, paste, autofill, or a programmatic set).
+  private static readonly MAX_FIELD_LENGTH = 256;
+
+  private readonly errorMessages = {
+    usernameOrEmail: {
+      required: 'Benutzername oder Email ist erforderlich',
+      maxlength: `Darf höchstens ${Login.MAX_FIELD_LENGTH} Zeichen lang sein`,
+    },
+    password: {
+      required: 'Passwort ist erforderlich',
+      maxlength: `Darf höchstens ${Login.MAX_FIELD_LENGTH} Zeichen lang sein`,
+    },
+  };
+
+  // The backend answers a wrong username/password with a single 401; there is no field-level
+  // detail to attach, so the failure surfaces as one form-level message instead.
+  readonly loginFailed = signal(false);
+
+  readonly loginModel = signal({
+    usernameOrEmail: '',
+    password: '',
+  });
+
+  readonly loginForm = form(
+    this.loginModel,
+    (schemaPath) => {
+      disabled(schemaPath, (ctx) => ctx.fieldTree().submitting());
+      required(schemaPath.usernameOrEmail, {
+        message: this.errorMessages.usernameOrEmail.required,
+      });
+      maxLength(schemaPath.usernameOrEmail, Login.MAX_FIELD_LENGTH, {
+        message: this.errorMessages.usernameOrEmail.maxlength,
+      });
+      required(schemaPath.password, { message: this.errorMessages.password.required });
+      maxLength(schemaPath.password, Login.MAX_FIELD_LENGTH, {
+        message: this.errorMessages.password.maxlength,
+      });
+    },
+    {
+      submission: {
+        action: async () => {
+          this.loginFailed.set(false);
+          const success = await this.authService.login(this.loginModel());
+          if (!success) {
+            this.loginFailed.set(true);
+          }
+        },
+      },
+    },
+  );
+
+  constructor() {
+    // A rejected-credentials message is form-level state; clear it as soon as the user edits either
+    // field so a stale "invalid credentials" error doesn't linger while they correct their input.
+    effect(() => {
+      this.loginModel();
+      this.loginFailed.set(false);
+    });
+  }
+}

--- a/src/test/java/ch/ethy/recipes/security/AuthControllerTest.java
+++ b/src/test/java/ch/ethy/recipes/security/AuthControllerTest.java
@@ -11,7 +11,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import ch.ethy.recipes.user.Role;
 import jakarta.servlet.http.Cookie;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -79,6 +82,23 @@ class AuthControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"usernameOrEmail\":\"alice\",\"password\":\"wrong\"}"))
         .andExpect(status().isUnauthorized());
+  }
+
+  static Stream<String> invalidLoginInputs() {
+    String overlong = "a".repeat(257);
+    return Stream.of(
+        "{\"usernameOrEmail\":\"\",\"password\":\"\"}", // blank fields
+        "{}", // fields missing entirely (null)
+        "{\"usernameOrEmail\":\"alice\",\"password\":\"" + overlong + "\"}", // password too long
+        "{\"usernameOrEmail\":\"" + overlong + "\",\"password\":\"pw\"}"); // username too long
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidLoginInputs")
+  void loginWithInvalidInputReturns400(String body) throws Exception {
+    mockMvc
+        .perform(post("/api/auth/login").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements the frontend login feature (#178), which had never been built — the `Login` component was an empty stub and `AuthService` had no `login()` method, so users could not log in through the UI.

- **`AuthService.login(credentials)`** — `POST /api/auth/login` with `withCredentials` (so the browser stores the `HttpOnly` refresh cookie), stores the access token in memory, navigates to the landing route (`/`) on success, and resolves `false` on a 401 so the form can show an inline error. Other errors propagate.
- **`Login` component** — thin, `OnPush`, Material signal-form (username-or-email + password) mirroring `Register`: required-field validation, a form-level "Ungültige Anmeldedaten" message on rejected credentials, and disable/spinner during submission. Logic lives in the service.
- **Backend hardening** — `LoginCredentials` gains `@NotBlank` and the controller `@Valid`, so blank/missing fields return **400** before authentication is attempted instead of surfacing as a 500. This adds `spring-boot-starter-validation`, realizing the Bean Validation convention already documented for request DTOs.
- **Docs** — arc42 runtime view notes the login 401/400 contracts.

## Out of scope (deliberate)

- **No post-login landing page** — there's no home/recipe-list route yet (#120), so login navigates to `/` (empty outlet under the toolbar for now).
- **No route guard / auto-redirect to `/login`** — all current routes are public; the redirect kicks in for free once authenticated API calls exist to trigger the refresh→logout path. Verified manually: login works, errors display correctly.
- **Logout UI** remains #179.

## Test plan

- [x] `./mvnw test` — backend tests + frontend lint/format/tests all green (36 frontend tests)
- [x] New backend test: blank credentials → 400
- [x] New specs: `AuthService.login()` success + 401 paths; `Login` form validation, submit, error display, submitting state
- [x] Manual: login succeeds, form renders, all error messages display correctly

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)