### PR TITLE
feat(security): validate the register endpoint and form

### DIFF
--- a/src/main/java/ch/ethy/recipes/security/AuthController.java
+++ b/src/main/java/ch/ethy/recipes/security/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
   }
 
   @PostMapping("/register")
-  public ResponseEntity<?> register(@RequestBody RegistrationDetails registrationDetails) {
+  public ResponseEntity<?> register(@RequestBody @Valid RegistrationDetails registrationDetails) {
     try {
       this.authService.register(registrationDetails);
       return ResponseEntity.ok().build();

--- a/src/main/java/ch/ethy/recipes/security/RegistrationDetails.java
+++ b/src/main/java/ch/ethy/recipes/security/RegistrationDetails.java
@@ -1,6 +1,10 @@
 package ch.ethy.recipes.security;
 
-import jakarta.annotation.Nonnull;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record RegistrationDetails(
-    @Nonnull String username, @Nonnull String email, @Nonnull String password) {}
+    @NotBlank @Size(max = 255) String username,
+    @NotBlank @Size(max = 255) @Email String email,
+    @NotBlank @Size(max = 255) String password) {}

--- a/src/main/webapp/app/security/auth.service.spec.ts
+++ b/src/main/webapp/app/security/auth.service.spec.ts
@@ -96,6 +96,43 @@ describe('AuthService', () => {
     expect(routerSpy.navigate).not.toHaveBeenCalled();
   });
 
+  it("register routes to the success page and resolves a definite success, not navigation()'s result", async () => {
+    // A navigation hiccup must not masquerade as a failed registration.
+    routerSpy.navigate.mockResolvedValue(false);
+
+    const promise = service.register({ username: 'u', email: 'u@example.com', password: 'pw' });
+
+    const req = httpMock.expectOne('/api/auth/register');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'u', email: 'u@example.com', password: 'pw' });
+    req.flush(null);
+
+    expect(await promise).toBe(true);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['register', 'success']);
+  });
+
+  it('register surfaces a 409 as the conflicting fields without navigating', async () => {
+    const promise = service.register({ username: 'taken', email: 'u@example.com', password: 'pw' });
+
+    httpMock
+      .expectOne('/api/auth/register')
+      .flush({ conflictingFields: ['username'] }, { status: 409, statusText: 'Conflict' });
+
+    expect(await promise).toEqual({ conflictingFields: ['username'] });
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it('register propagates non-409 errors instead of swallowing them', async () => {
+    const promise = service.register({ username: 'u', email: 'u@example.com', password: 'pw' });
+
+    httpMock
+      .expectOne('/api/auth/register')
+      .flush(null, { status: 500, statusText: 'Server Error' });
+
+    await expect(promise).rejects.toBeTruthy();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
   it('logout clears the in-memory token, asks the backend to drop the cookie, and routes to login', () => {
     service.logout();
 

--- a/src/main/webapp/app/security/auth.service.ts
+++ b/src/main/webapp/app/security/auth.service.ts
@@ -50,10 +50,15 @@ export class AuthService {
   // when the request settles so the next burst starts fresh.
   private refreshInFlight$: Observable<string> | null = null;
 
+  // Resolves true on success (routed to the success page) and the conflicting fields on a duplicate
+  // (409) so the form can flag them. Other failures propagate.
   async register(details: RegistrationDetails): Promise<DuplicateUserError | boolean> {
     return firstValueFrom(
       this.http.post('/api/auth/register', details).pipe(
         switchMap(() => this.router.navigate(['register', 'success'])),
+        // Resolve a definite "registration succeeded" rather than navigate()'s result, so a
+        // navigation hiccup can't masquerade as a failed registration.
+        map(() => true),
         catchError((error: HttpErrorResponse) => {
           if (error.status === 409) {
             return of(error.error as DuplicateUserError);

--- a/src/main/webapp/app/security/register/register.spec.ts
+++ b/src/main/webapp/app/security/register/register.spec.ts
@@ -40,6 +40,34 @@ describe('Register', () => {
     expect(component.registerForm.email().errors().length).toBe(0);
   });
 
+  it('caps every field at 255 characters in the DOM, mirroring the backend', () => {
+    // Signal forms emit a generated name like "ng.form0.username"; match the stable leaf suffix so
+    // the assertion targets each field explicitly rather than relying on DOM order.
+    const field = (name: string): HTMLInputElement =>
+      fixture.nativeElement.querySelector(`input[name$=".${name}"]`);
+
+    expect(field('username').maxLength).toBe(255);
+    expect(field('email').maxLength).toBe(255);
+    expect(field('password').maxLength).toBe(255);
+  });
+
+  it('rejects values over 255 characters with a maxlength error set through the model', () => {
+    component.registerModel.set({
+      username: 'a'.repeat(256),
+      email: 'a'.repeat(249) + '@ex.com',
+      password: 'b'.repeat(256),
+    });
+    TestBed.flushEffects();
+
+    const maxLengthFired = (errors: { kind: string }[]): boolean =>
+      errors.some((e) => e.kind === 'maxLength');
+
+    expect(maxLengthFired(component.registerForm.username().errors())).toBe(true);
+    expect(maxLengthFired(component.registerForm.email().errors())).toBe(true);
+    expect(maxLengthFired(component.registerForm.password().errors())).toBe(true);
+    expect(component.registerForm().valid()).toBe(false);
+  });
+
   it('should be valid when all fields are filled with valid data', () => {
     component.registerModel.set({ username: 'user', email: 'user@example.com', password: 'pass' });
     TestBed.flushEffects();

--- a/src/main/webapp/app/security/register/register.ts
+++ b/src/main/webapp/app/security/register/register.ts
@@ -1,7 +1,15 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { MatCard, MatCardContent, MatCardHeader, MatCardTitle } from '@angular/material/card';
 import { MatError, MatFormField, MatInput, MatLabel } from '@angular/material/input';
-import { disabled, email, form, FormField, FormRoot, required } from '@angular/forms/signals';
+import {
+  disabled,
+  email,
+  form,
+  FormField,
+  FormRoot,
+  maxLength,
+  required,
+} from '@angular/forms/signals';
 import { MatButton } from '@angular/material/button';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { AuthService } from '../auth.service';
@@ -29,18 +37,26 @@ import { AuthService } from '../auth.service';
 export class Register {
   private authService = inject(AuthService);
 
+  // Mirrors the backend @Size cap on RegistrationDetails (itself aligned to the VARCHAR(255)
+  // column width) so an over-long value can never be submitted, however it reaches the model
+  // (typing, paste, autofill, or a programmatic set).
+  private static readonly MAX_FIELD_LENGTH = 255;
+
   private readonly errorMessages: Record<string, Record<string, string>> = {
     username: {
       required: 'Benutzername ist erforderlich',
+      maxlength: `Darf höchstens ${Register.MAX_FIELD_LENGTH} Zeichen lang sein`,
       duplicate: 'Benutzername ist bereits vergeben',
     },
     email: {
       required: 'Email ist erforderlich',
       invalid: 'Email ist ungültig',
+      maxlength: `Darf höchstens ${Register.MAX_FIELD_LENGTH} Zeichen lang sein`,
       duplicate: 'Email ist bereits vergeben',
     },
     password: {
       required: 'Passwort ist erforderlich',
+      maxlength: `Darf höchstens ${Register.MAX_FIELD_LENGTH} Zeichen lang sein`,
     },
   };
 
@@ -55,9 +71,18 @@ export class Register {
     (schemaPath) => {
       disabled(schemaPath, (ctx) => ctx.fieldTree().submitting());
       required(schemaPath.username, { message: this.errorMessages['username']['required'] });
+      maxLength(schemaPath.username, Register.MAX_FIELD_LENGTH, {
+        message: this.errorMessages['username']['maxlength'],
+      });
       required(schemaPath.email, { message: this.errorMessages['email']['required'] });
       email(schemaPath.email, { message: this.errorMessages['email']['invalid'] });
+      maxLength(schemaPath.email, Register.MAX_FIELD_LENGTH, {
+        message: this.errorMessages['email']['maxlength'],
+      });
       required(schemaPath.password, { message: this.errorMessages['password']['required'] });
+      maxLength(schemaPath.password, Register.MAX_FIELD_LENGTH, {
+        message: this.errorMessages['password']['maxlength'],
+      });
     },
     {
       submission: {

--- a/src/test/java/ch/ethy/recipes/security/AuthControllerTest.java
+++ b/src/test/java/ch/ethy/recipes/security/AuthControllerTest.java
@@ -3,6 +3,7 @@ package ch.ethy.recipes.security;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ch.ethy.recipes.user.Role;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -99,6 +101,92 @@ class AuthControllerTest {
     mockMvc
         .perform(post("/api/auth/login").contentType(MediaType.APPLICATION_JSON).content(body))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void loginAtTheMaxLengthBoundaryIsAccepted() throws Exception {
+    when(authService.login(any()))
+        .thenReturn(new AuthTokens("access-1", "refresh-1", Set.of(Role.USER)));
+    String maxLength = "a".repeat(256); // exactly the @Size(max) cap — must pass, not 400
+
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"usernameOrEmail\":\""
+                        + maxLength
+                        + "\",\"password\":\""
+                        + maxLength
+                        + "\"}"))
+        .andExpect(status().isOk());
+  }
+
+  static Stream<String> invalidRegisterInputs() {
+    String overlong = "a".repeat(256); // one over the 255 cap (and the VARCHAR(255) column width)
+    String overlongEmail = "a".repeat(249) + "@ex.com"; // 256 chars, still a valid address shape
+    return Stream.of(
+        "{\"username\":\"\",\"email\":\"\",\"password\":\"\"}", // blank fields
+        "{}", // fields missing entirely (null)
+        "{\"username\":\"alice\",\"email\":\"not-an-email\",\"password\":\"pw\"}", // malformed
+        // email
+        "{\"username\":\""
+            + overlong
+            + "\",\"email\":\"a@b.com\",\"password\":\"pw\"}", // username too long
+        "{\"username\":\"alice\",\"email\":\""
+            + overlongEmail
+            + "\",\"password\":\"pw\"}", // email too long
+        "{\"username\":\"alice\",\"email\":\"a@b.com\",\"password\":\""
+            + overlong
+            + "\"}"); // password too long
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidRegisterInputs")
+  void registerWithInvalidInputReturns400(String body) throws Exception {
+    mockMvc
+        .perform(post("/api/auth/register").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void registerWithValidInputReturns200() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"username\":\"alice\",\"email\":\"alice@example.com\",\"password\":\"pw\"}"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void registerWithDuplicateUserReturns409() throws Exception {
+    doThrow(new DuplicateUserException(List.of("username"))).when(authService).register(any());
+
+    mockMvc
+        .perform(
+            post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"username\":\"taken\",\"email\":\"alice@example.com\",\"password\":\"pw\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.conflictingFields[0]").value("username"));
+  }
+
+  @Test
+  void registerAtTheMaxLengthBoundaryIsAccepted() throws Exception {
+    String maxUsername = "a".repeat(255); // exactly the @Size(max) cap — must pass, not 400
+
+    mockMvc
+        .perform(
+            post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"username\":\""
+                        + maxUsername
+                        + "\",\"email\":\"alice@example.com\",\"password\":\"pw\"}"))
+        .andExpect(status().isOk());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Applies Jakarta Bean Validation to the registration path, bringing it in line with the login endpoint hardened in #178. Closes the long-password BCrypt DoS that still existed on `/register` and removes the latent `register()` navigation-result quirk.

### Backend
- `RegistrationDetails`: replace the runtime-inert JSR-305 `@Nonnull` with `@NotBlank` + `@Size(max=255)` on all three fields, and add `@Email` on the address (defense in depth — the frontend already validates format). The cap is 255 to match the `VARCHAR(255)` user columns, so an over-long value is rejected with 400 rather than passing validation and failing on insert as a 500.
- `AuthController.register`: add `@Valid` so blank, missing, malformed-email, or over-long input is rejected with **400** before the service runs. Capping `password` bounds the BCrypt work (it is hashed before storage, so its cap is a DoS bound rather than a column-width constraint).

### Frontend
- Register form: `maxLength(255)` signal-form validators on all three fields (model-level, so an over-long value can't be submitted via paste/autofill/programmatic set — not just the bypassable native DOM attribute).
- `AuthService.register()`: resolve a definite `true` on success via a trailing `map(() => true)` instead of returning `navigate()`'s boolean, so a navigation hiccup can't masquerade as a failed registration — matching the earlier `login()` fix.

## Acceptance criteria (#183)
- [x] Blank, missing, or over-long register fields return 400 before the service runs
- [x] `RegistrationDetails.password` is capped, closing the long-password DoS on `/register`
- [x] Register form rejects over-long values set through the model, not just typed
- [x] `AuthService.register()` success no longer depends on the navigation result
- [x] Server-side `@Email` added (the issue's open question)

## Test plan
- Backend: parameterized `registerWithInvalidInputReturns400` covering blank, missing, malformed email, and over-long username/email/password (boundary at exactly 256); `registerWithValidInputReturns200`, `registerWithDuplicateUserReturns409`, and `registerAtTheMaxLengthBoundaryIsAccepted` (255 accepted). A matching `loginAtTheMaxLengthBoundaryIsAccepted` pins login's 256 boundary from the accept side.
- Frontend: `AuthService` specs for register success (definite `true`), 409 conflict, non-409 propagation; register component specs for the DOM cap (queried by field name) and model-level over-length rejection.
- `npm run lint:check`, `npm run format:check`, and `mvn spotless:check` all clean.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)