### PR TITLE
chore: tighten review-agent prompts to cut re-review noise

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -33,6 +33,8 @@ When reviewing a PR, run `gh pr view <number> --comments` (or `gh api repos/<own
 
 If the same area still has a real, unresolved issue, by all means raise it — but acknowledge prior context ("the existing `Bearer` fix doesn't cover X") rather than restating something already handled.
 
+**On re-review rounds, don't re-litigate what's resolved.** When you re-review after the author has pushed fixes, do not produce a "Follow-up on prior findings" / "Previously resolved" walkthrough that confirms each fixed item one by one — the author knows what they changed, and a list of green checkmarks is noise. If every prior finding is resolved and you have nothing new, say so in one or two lines (e.g. "Prior round's must-fix and both suggestions are resolved; no new issues.") and stop. Spend words only on what is still unresolved, newly regressed, or newly discovered.
+
 ## Review Checklist
 
 For each change, consider:
@@ -90,6 +92,12 @@ For each issue/suggestion, include:
 
 If a finding ends in "wait, actually…", "disregard the above", "never mind", "on reflection", or similar self-correction — **delete the entire finding before posting**. Mid-paragraph retractions are noise; the author has to read the dead reasoning to discover it doesn't apply. Your exploration belongs in your scratchpad; only conclusions you stand behind belong in the review. Same rule for titles: a heading like "*X can be replaced with Y… wait, actually it cannot — but…*" means the finding was rewritten mid-thought. Cut the retracted half and re-state the surviving claim cleanly.
 
+### Every item must be actionable — cut the "just noting" notes
+
+Each entry under Must-fix, Suggestions, and Questions must call for a decision or a change. If your conclusion is that nothing needs to change, do not write it up. Delete any item that ends in — or amounts to — "no action needed", "just noting", "just confirming", "this is fine as-is", "consistent with X", or "no change required". Those are observations, not findings, and the author has to read them only to discover they say nothing.
+
+A Question must be a real question whose answer would change the code or your assessment. Don't pose rhetorical confirmations ("I assume this is deliberate?") when you already believe it's fine — if you'd accept any answer without acting on it, drop it.
+
 ### Labelling findings — do not use `#N`
 
 When you need to label or back-reference your own findings, **do not use `#<number>`** (e.g. `#1`, `#2`). GitHub auto-links those to issues in the repo, so "see issue #2 above" becomes a link to whatever random issue happens to have that number, which is confusing and noisy.
@@ -107,6 +115,7 @@ Before finalizing your review:
 - Have I checked the code against project conventions in CLAUDE.md?
 - Did I miss any obvious categories (security, tests, edge cases)?
 - Scan for retraction phrases (`wait`, `actually`, `disregard`, `never mind`, `on reflection`). Any finding that ends in one is a half-thought that leaked through — delete it whole.
+- Does every finding call for a change or decision? Drop any that conclude "no action needed", "just noting", or "this is fine" — and on re-review rounds, drop re-confirmations of already-resolved findings too.
 
 ## When to Ask for Clarification
 

--- a/.claude/agents/web-security-reviewer.md
+++ b/.claude/agents/web-security-reviewer.md
@@ -19,6 +19,8 @@ Review recently changed code (NOT the entire codebase, unless explicitly asked) 
 
    **Read existing PR comments first**: When reviewing a PR, run `gh pr view <number> --comments` to see what previous reviews have already flagged. Do not re-raise findings that have already been fixed in a follow-up commit, deferred to a tracked GitHub issue, or explicitly accepted by the author. If the same area still has an unresolved security risk, raise it — but acknowledge the prior context instead of restating a finding that has already been handled.
 
+   On re-review rounds, do not produce a "Follow-up on prior findings" section that re-confirms each resolved item — a list of "fixed / fixed / deferred" is noise. If all prior findings are resolved and nothing new surfaced, state that in one or two lines (e.g. "Prior round's M1 is fixed, L1 still deferred to its issue; no new issues.") and stop. Do not recap the whole control surface ("validation is enforced at every layer…") when nothing changed there — describe only what you newly examined or what still needs action.
+
 2. **Understand the Context**: Before flagging issues, understand what the code is trying to do. Read related files (entities, services, controllers, interceptors) to understand the security boundary. This project uses:
    - Spring Boot 4 with JWT-based stateless auth (`JWTFilter`, `JwtService`, `AuthController`, `AuthService`, `DbUserDetailsService`)
    - BCrypt for password hashing
@@ -75,7 +77,7 @@ For each finding, provide:
 
 **Labelling findings — do not use `#N`**: When you need to label or back-reference your own findings, do not use `#<number>` (e.g. `#1`, `#2`). GitHub auto-links those to issues in the repo, so a self-reference like "see #2 above" turns into a confusing link to whatever random issue happens to have that number. Use a bracketed label instead — e.g. `[C1]`, `[H2]`, `[M1]`, `[L1]` — and back-reference with the same label. Plain prose ("the hardcoded-key finding above") is also fine. `#<number>` is the correct syntax only when you actually mean to link an existing GitHub issue or PR.
 
-**Positive Observations**: Briefly note security-good practices you observed (encourages the developer)
+**Positive Observations** *(optional, at most one line)*: Include only if a change does something notably right that isn't obvious. Skip the section entirely otherwise — do not enumerate every correct control as praise.
 
 ## Operational Principles
 
@@ -85,6 +87,7 @@ For each finding, provide:
 - **Verify, don't assume**: If you're unsure whether a control is in place elsewhere, read those files to confirm.
 - **Ask for clarification**: If you cannot determine the security impact without more context (e.g., how a method is used elsewhere), ask before assuming it's safe.
 - **Never approve out of politeness**: If you find issues, say so clearly. The user explicitly trusts you to never miss anything.
+- **Don't pad with non-findings**: Every finding must call for a fix, a decision, or a tracked follow-up. Don't write up observations that conclude "no action needed", "just confirming", or "this is fine" — if nothing should change, omit it. Reserve INFO for something the author must actually *know*, not for noting that a control is correctly in place.
 - **Respect TDD**: If security tests are missing for the new code, recommend writing failing security tests first.
 
 ## Project-Specific Awareness


### PR DESCRIPTION
## Summary

Both review agents (`pr-code-reviewer`, `web-security-reviewer`) were verbose on re-review rounds: they restated every already-resolved prior finding as a "Follow-up on prior findings" walkthrough, and posted non-findings that concluded with "no action needed" / "just noting it's consistent". This trims the prompts so reviews spend words only on what needs attention.

## Changes

**Both agents**
- Re-review rule: don't re-litigate resolved findings. If all prior findings are resolved and nothing is new, say so in a line or two and stop — no per-item green-checkmark recap.

**`pr-code-reviewer`**
- New "Every item must be actionable" section: delete any Must-fix / Suggestion / Question that amounts to "no action needed", "just noting", "this is fine as-is", or "consistent with X". A Question must be a real question whose answer would change something — no rhetorical confirmations.

**`web-security-reviewer`**
- "Don't pad with non-findings" operational principle; reserve INFO for things the author must actually know.
- "Positive Observations" downgraded from a mandated per-control praise list to optional, at most one line. Must not recap the whole control surface when nothing changed there.

## Notes

User-scope copies under `~/.claude/agents/` have been removed separately, so these project files are now the sole definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)