### PR TITLE
ci: run PR reviews on the latest Fable model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,6 +83,7 @@ jobs:
             reviewer, e.g. `## pr-code-reviewer`, `## web-security-reviewer`. Do
             not merge them into a single comment — keep each review distinct.
           claude_args: >-
+            --model fable
             --max-turns 25
             --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

The review workflow ran on the action's default model (latest Sonnet) while development happens on Fable — the inverse of what you want from a quality gate, where the reviewer should be at least as capable as the author. This adds `--model fable` to the `claude_args` of `claude-code-review.yml`; the alias tracks the newest Fable-family model, so no re-pinning is needed when the next generation lands.

The `@claude` mention workflow (`claude.yml`) intentionally stays on the default: it is used interactively and casually, and review runs are the token-heavy path. If plan usage draws down too fast after a few PRs, reverting this single line restores the previous behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)