### PR TITLE
ci: manage GitHub Actions via Dependabot and pin them by SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Node.js 24.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.16.0'
           cache: 'npm'
@@ -22,7 +22,7 @@ jobs:
         run: npm run lint
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Look up cache for this diff
         id: diff-cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .claude-review-marker
           key: claude-review-pr-${{ github.event.pull_request.number }}-${{ steps.diff-hash.outputs.hash }}
@@ -56,7 +56,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.diff-cache.outputs.cache-hit != 'true'
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca # v1.0.144
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node.js 24.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.16.0'
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -43,7 +43,7 @@ jobs:
         run: mvn -B clean test
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

- Add the `github-actions` ecosystem to `dependabot.yml` so workflow actions receive update PRs like every other dependency. Deliberately ungrouped: action updates stay as individual PRs so each can be merged or declined on its own (npm groups exist only for packages that must move together).
- Bump all referenced actions to their current releases and pin every reference by full commit SHA with a version comment:
  - `actions/checkout` v3/v4 → v6.0.3
  - `actions/setup-node` v3 → v6.4.0
  - `actions/setup-java` v3 → v5.2.0
  - `actions/cache` v4 → v5.0.5
  - `docker/login-action` v3 → v4.2.0
  - `anthropics/claude-code-action` v1 → v1.0.144 (the moving `v1` tag currently points at exactly this commit)

Dependabot understands the `@<sha> # vX.Y.Z` format and keeps both the SHA and the comment current, while a force-moved or compromised tag can no longer inject code into CI — most relevant in `release.yml`, which holds publish credentials. The major jumps mainly move actions onto the Node 24 runner; all inputs we use are unchanged across these versions.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)