### PR TITLE
ci: pin review workflow to the opus tier alias instead of fable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,7 +83,7 @@ jobs:
             reviewer, e.g. `## pr-code-reviewer`, `## web-security-reviewer`. Do
             not merge them into a single comment — keep each review distinct.
           claude_args: >-
-            --model fable
+            --model opus
             --max-turns 25
             --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary
The Claude review check started failing because the workflow pinned `--model fable`, which no longer resolves for the action's OAuth token. This swaps it for the `opus` tier alias.

Tier aliases (`opus`/`sonnet`/`haiku`) self-track the latest available model in their family, so they stay valid across model launches and retirements without a workflow edit.

> Note: the review check on this PR will still report red — a PR that modifies `claude-code-review.yml` doesn't run its own modified self. The fix takes effect once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)