### PR TITLE
ci: dedupe build runs and validate the Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,9 @@ jobs:
 
       - name: build backend
         run: mvn -B -DskipTests=true clean install
+
+      # Exercises the same Dockerfile the release builds (semantic-release
+      # publishCmd in package.json). The jar is packaged by a different
+      # maven command there, so this validates the Dockerfile, not that build.
+      - name: build Docker image
+        run: docker build -t recipes:ci .


### PR DESCRIPTION
## Summary
The Dockerfile was only built inside semantic-release's `publishCmd` (`package.json:77`), which runs solely when a release is cut — so a `build:`/`chore:` change to it (like the recent Java 25 base-image work) was never exercised by CI. This adds a `docker build` step so the image is assembled on every run, using the jar produced by the existing `mvn install` step. Build-only: no login, no push. A comment on the step notes it mirrors the release image build so the two stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)