### PR TITLE
docs: strip class names from arc42, add project README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,13 +60,21 @@ A recipe management web application with a Spring Boot (Java) backend and Angula
 - **Angular components**: Use standalone components (no NgModules) and `ChangeDetectionStrategy.OnPush`
 - **Backend DTOs**: Use Jakarta Bean Validation annotations on request DTOs; invalid input yields a 400 with field-level errors
 
-## Environment Variables
+## Configuration
 
-- `DB_HOST` / `DB_PORT` — MySQL connection (defaults: localhost:3306)
-- `DB_PASSWORD` — MySQL app user password
-- `FLYWAY_PASSWORD` — Flyway migration user password
-- `JWT_SECRET` — Base64-encoded HMAC-SHA256 signing key for JWTs (required; minimum 32 bytes / 256 bits, but generate with `openssl rand -base64 48` for headroom)
-- `JWT_ACCESS_TTL` — Access-token lifetime as an ISO-8601 duration (default `PT15M`, maximum `P30D`). The access token is sent on every request and is rejected once expired, missing its `exp` claim, or once its embedded per-user token version no longer matches the user's current version (revocation).
-- `JWT_REFRESH_TTL` — Refresh-token lifetime as an ISO-8601 duration (default `P7D`, maximum `P30D`). The refresh token is delivered as an `HttpOnly` cookie; the client exchanges it at `POST /api/auth/refresh` for a fresh access token (and a rotated refresh cookie). The refresh re-reads the user, so a role change takes effect on the next refresh.
-- `REFRESH_COOKIE_SECURE` — Whether the refresh-token cookie carries the `Secure` attribute (default `true`). The `dev` profile sets it to `false` so the cookie works over plain-HTTP localhost. Keep it `true` behind an SSL-terminating reverse proxy: the browser↔proxy connection is HTTPS, so `Secure` still applies even though the proxy forwards plain HTTP internally.
-- `LOGIN_FAILURE_DELAY` — How long a failed login (bad credentials) is held before its 401 is returned, as an ISO-8601 duration (default `PT1S`, maximum `PT10S`, `PT0S` disables). Slows online brute-force/credential-stuffing; successful logins and validation 400s are unaffected. The wait is asynchronous (the suspended request holds no request thread).
+Runtime config is supplied via environment variables. `src/main/resources/application.yaml`
+is the source of truth; the README lists every variable with its default. Don't re-document
+the full list or defaults here — keep them in one place to avoid drift.
+
+Behavioral facts worth keeping in mind when touching auth (canonical detail in arc42 §8.1):
+
+- **Access token** (`JWT_ACCESS_TTL`): sent on every request; rejected once expired, missing
+  its `exp` claim, or once its embedded per-user **token version** no longer matches the user's
+  current version (this is the revocation mechanism).
+- **Refresh token** (`JWT_REFRESH_TTL`): `HttpOnly` cookie exchanged at `POST /api/auth/refresh`
+  for a fresh access token and a rotated cookie. Refresh **re-reads the user**, so a role change
+  takes effect on the next refresh. Lifetime is rolling (each refresh restarts it).
+- **`REFRESH_COOKIE_SECURE`**: the `dev` profile sets it `false` for plain-HTTP localhost; keep
+  it `true` in production (still applies behind an HTTPS-terminating reverse proxy).
+- **`LOGIN_FAILURE_DELAY`**: failed logins are held before the 401; the wait is asynchronous, so
+  it holds no request thread and can't be turned into a thread-pool exhaustion lever.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# Recipes
+
+[![Build](https://github.com/MonsieurBon/recipes/actions/workflows/build.yml/badge.svg)](https://github.com/MonsieurBon/recipes/actions/workflows/build.yml)
+[![Release](https://img.shields.io/github/v/release/MonsieurBon/recipes)](https://github.com/MonsieurBon/recipes/releases)
+
+A recipe management web application: browse and manage recipes, mark favorites, and plan
+meals for the week.
+
+> [!NOTE]
+> This project is under active development. Recipe management, favorites, and meal planning
+> are being built out incrementally — see the [architecture docs](docs/arc42/) for the target
+> design and current status.
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- **Docker**
+- A reachable **MySQL 8** instance with a `recipes` database
+
+### Database Setup
+
+Flyway runs the migrations as a dedicated `recipes-flyway` user and, on first migration,
+creates the lower-privilege `recipes` application user that the app uses at runtime. Create
+the database and the migration user once:
+
+```sql
+CREATE DATABASE recipes;
+
+CREATE USER 'recipes-flyway' IDENTIFIED BY 'your-flyway-password';
+GRANT ALL PRIVILEGES ON recipes.* TO 'recipes-flyway';
+-- The first migration creates the runtime 'recipes' user AND grants it privileges, so the
+-- migration user needs CREATE USER plus GRANT OPTION to delegate them. Omitting GRANT OPTION
+-- makes the migration fail with a non-obvious "access denied" error.
+GRANT CREATE USER ON *.* TO 'recipes-flyway' WITH GRANT OPTION;
+```
+
+The runtime `recipes` user is created automatically with `SELECT, INSERT, UPDATE, DELETE` on
+the `recipes` schema; its password is set from `DB_PASSWORD` (see below).
+
+### Running the Application
+
+A container image is published to the GitHub Container Registry on each release. Provide the
+required environment variables (see [Configuration](#configuration)) and run it:
+
+```bash
+docker run -p 8080:8080 \
+  -e DB_HOST=host.docker.internal \
+  -e DB_PASSWORD='your-app-password' \
+  -e FLYWAY_PASSWORD='your-flyway-password' \
+  -e JWT_SECRET="$(openssl rand -base64 48)" \
+  ghcr.io/monsieurbon/recipe:latest
+```
+
+The application starts on <http://localhost:8080>. Use a specific release tag in place of
+`latest` to pin a version.
+
+> [!TIP]
+> Behind an SSL-terminating reverse proxy the refresh-token cookie's `Secure` attribute works
+> as-is. If you expose the app over plain HTTP (no HTTPS proxy), also set
+> `-e REFRESH_COOKIE_SECURE=false` so the cookie is accepted.
+
+### Configuration
+
+All configuration is supplied through environment variables. Durations use
+[ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format (e.g. `PT15M`,
+`P7D`).
+
+| Variable                | Description                                                                                                   | Default     | Required |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- | ----------- | :------: |
+| `DB_HOST`               | MySQL host                                                                                                     | `localhost` |          |
+| `DB_PORT`               | MySQL port                                                                                                     | `3306`      |          |
+| `DB_PASSWORD`           | Password for the runtime `recipes` application user                                                           | —           |    ✅    |
+| `FLYWAY_PASSWORD`       | Password for the `recipes-flyway` migration user                                                              | —           |    ✅    |
+| `JWT_SECRET`            | Base64-encoded HMAC-SHA256 signing key for JWTs. Minimum 32 bytes; generate with `openssl rand -base64 48`     | —           |    ✅    |
+| `JWT_ACCESS_TTL`        | Access-token lifetime (sent on every request, rejected once expired or revoked). Max `P30D`                    | `PT15M`     |          |
+| `JWT_REFRESH_TTL`       | Refresh-token lifetime (`HttpOnly` cookie exchanged at `POST /api/auth/refresh`; rolling). Max `P30D`          | `P7D`       |          |
+| `REFRESH_COOKIE_SECURE` | Whether the refresh-token cookie carries the `Secure` attribute. Keep `true` behind an HTTPS reverse proxy     | `true`      |          |
+| `LOGIN_FAILURE_DELAY`   | Delay before a failed login returns its 401, slowing brute-force. Max `PT10S`; `PT0S` disables                 | `PT1S`      |          |
+
+> [!IMPORTANT]
+> `JWT_SECRET` has no default and the app **will not start** without a valid key of at least
+> 32 bytes. Generate one with `openssl rand -base64 48` for headroom.
+
+## Documentation
+
+Architecture and design decisions are documented using the
+[arc42](https://arc42.org/) template in [`docs/arc42/`](docs/arc42/).

--- a/docs/arc42/05-building-block-view.md
+++ b/docs/arc42/05-building-block-view.md
@@ -23,83 +23,77 @@
 
 ```
 ch.ethy.recipes
-+---------------------------------------------------+
-|  security/                                        |
-|    AuthController          REST: /api/auth/**     |
-|    AuthService             Login/register logic   |
-|    JWTFilter, JwtService   Token handling         |
-|    SecurityConfig          Spring Security setup  |
-|                                                   |
-|  user/                                            |
-|    UserController          REST: /api/users/**    |
-|    UserService             User management        |
-|    UserRepository          JPA persistence        |
-|                                                   |
-|  recipe/ (planned)                                |
-|    RecipeController        REST: /api/recipes/**  |
-|    RecipeService           Recipe CRUD & search   |
-|    RecipeRepository        JPA persistence        |
-|                                                   |
-|  favorite/ (planned)                              |
-|    FavoriteController      REST: /api/favorites   |
-|    FavoriteService         Favorite management    |
-|    FavoriteRepository      JPA persistence        |
-|                                                   |
-|  mealplan/ (planned)                              |
-|    MealPlanController      REST: /api/meal-plans  |
-|    MealPlanService         Plan CRUD              |
-|    SuggestionService       Meal suggestions       |
-|    MealPlanRepository      JPA persistence        |
-|                                                   |
-|  admin/ (planned)                                 |
-|    AdminUserController     REST: /api/admin/users |
-|    AdminRecipeController   REST: /api/admin/...   |
-|    AdminIngredientCtrl     REST: /api/admin/...   |
-|    (ADMIN role required; reuses domain services)  |
-|                                                   |
-|  db/                                              |
-|    BaseEntity              Shared JPA base class  |
-|                                                   |
-|  AngularForwardController  SPA route forwarding   |
-+---------------------------------------------------+
++--------------------------------------------------------+
+|  security/                                             |
+|    Authentication endpoints (REST: /api/auth/**)       |
+|    Login / registration logic                          |
+|    Token issuance and validation                       |
+|    Per-request token check populates security context  |
+|    Spring Security configuration                       |
+|                                                        |
+|  user/                                                 |
+|    User-management endpoints (REST: /api/users/**)     |
+|    User persistence                                    |
+|                                                        |
+|  recipe/ (planned)                                     |
+|    Recipe endpoints (REST: /api/recipes/**)            |
+|    Recipe CRUD and search, persistence                 |
+|                                                        |
+|  favorite/ (planned)                                   |
+|    Favorite endpoints (REST: /api/favorites)           |
+|    Favorite management, persistence                    |
+|                                                        |
+|  mealplan/ (planned)                                   |
+|    Meal-plan endpoints (REST: /api/meal-plans)         |
+|    Plan CRUD, persistence                              |
+|    Meal-suggestion logic                               |
+|                                                        |
+|  admin/ (planned)                                      |
+|    Admin endpoints (REST: /api/admin/**)               |
+|    ADMIN role required; reuses domain services         |
+|                                                        |
+|  db/                                                   |
+|    Shared JPA base for entities                        |
+|                                                        |
+|  SPA route forwarding for non-API routes               |
++--------------------------------------------------------+
 ```
 
 ## 5.3 Level 2 -- Frontend Components
 
 ```
 src/main/webapp/app/
-+------------------------------------------------------+
-|  security/                                           |
-|    LoginComponent            Login form              |
-|    RegisterComponent         Registration form       |
-|    RegisterSuccessComponent                          |
-|    AuthService               Token management        |
-|    authenticationInterceptor JWT attachment          |
-|                                                      |
-|  recipe/ (planned)                                   |
-|    RecipeListComponent       Search & filter         |
-|    RecipeDetailComponent     Cooking view            |
-|    RecipeEditComponent       Add/edit recipe         |
-|    RecipeService             API communication       |
-|                                                      |
-|  favorite/ (planned)                                 |
-|    FavoriteService           Favorite toggling       |
-|                                                      |
-|  meal-plan/ (planned)                                |
-|    MealPlanComponent         Weekly plan view        |
-|    MealSlotConfigComponent   Slot configuration      |
-|    MealPlanService           API communication       |
-|    SuggestionService         Suggestion handling     |
-|                                                      |
-|  admin/ (planned)                                    |
-|    AdminShellComponent       Admin area layout/nav   |
-|    AdminUserListComponent    List & edit users       |
-|    AdminRecipeListComponent  List & edit recipes     |
-|    AdminIngredientListCmp    List & edit ingredients |
-|    AdminGuard                Restricts area to ADMIN |
-|    AdminService              API communication       |
-|                                                      |
-|  utility/                                            |
-|    LocalStorageService       Browser storage         |
-+------------------------------------------------------+
++------------------------------------------------+
+|  security/                                     |
+|    Login form                                  |
+|    Registration form and success view          |
+|    Token management                            |
+|    JWT attachment on outgoing requests         |
+|                                                |
+|  recipe/ (planned)                             |
+|    Recipe list (search and filter)             |
+|    Read-only cooking view                      |
+|    Add / edit recipe form                      |
+|    API communication                           |
+|                                                |
+|  favorite/ (planned)                           |
+|    Favorite toggling                           |
+|                                                |
+|  meal-plan/ (planned)                          |
+|    Weekly plan view                            |
+|    Slot configuration                          |
+|    Suggestion handling                         |
+|    API communication                           |
+|                                                |
+|  admin/ (planned)                              |
+|    Admin area layout and navigation            |
+|    User list and edit                          |
+|    Recipe list and edit                        |
+|    Ingredient list and edit                    |
+|    Route guard restricting area to ADMIN role  |
+|    API communication                           |
+|                                                |
+|  utility/                                      |
+|    Browser storage                             |
++------------------------------------------------+
 ```

--- a/docs/arc42/06-runtime-view.md
+++ b/docs/arc42/06-runtime-view.md
@@ -3,14 +3,14 @@
 ## 6.1 User Login
 
 ```
-Browser                  AuthController      AuthService       JwtService          DB
-  |-- POST /api/auth/login -->|                   |                   |             |
-  |                           |-- authenticate -->|                   |             |
-  |                           |                   |--- loadUser ------|------------>|
-  |                           |                   |<--- User ---------|-------------|
-  |                           |                   |-- issue tokens -->|             |
-  |                           |<- access+refresh -|<------------------|             |
-  |<-- 200 { token, roles } + Set-Cookie: refreshToken (HttpOnly) ----|             |
+Browser                 Auth API                 Tokens                  DB
+  |- POST /api/auth/login ---->                       |                   |
+  |                           |- verify credentials -->                   |
+  |                           |                       |- load user ------->
+  |                           |                       <- user ------------|
+  |                           |- issue tokens -------->                   |
+  |                           <- access + refresh ----|                   |
+  |<- 200 { token, roles } + Set-Cookie: refreshToken (HttpOnly)          |
 ```
 
 The access token is returned in the body; the refresh token is delivered out-of-band as an
@@ -20,15 +20,15 @@ missing or blanking either field is rejected with 400 before authentication is a
 ## 6.2 Token Refresh
 
 ```
-Browser                  AuthController      AuthService       JwtService          DB
-  |-- POST /api/auth/refresh ->|                  |                   |             |
-  |   Cookie: refreshToken     |-- refresh ------>|                   |             |
-  |                            |                  |-- parse/verify -->|             |
-  |                            |                  |--- loadUser ------|------------>|
-  |                            |                  |<--- User ---------|-------------|
-  |                            |                  |-- issue tokens -->|             |
-  |                            |<- access+refresh-|<------------------|             |
-  |<-- 200 { token, roles } + Set-Cookie: refreshToken (HttpOnly) ----|             |
+Browser                 Auth API                 Tokens                  DB
+  |- POST /api/auth/refresh -->                       |                   |
+  |  Cookie: refreshToken     |                       |                   |
+  |                           |- parse / verify token >                   |
+  |                           |                       |- load user ------->
+  |                           |                       <- user ------------|
+  |                           |- issue tokens -------->                   |
+  |                           <- access + refresh ----|                   |
+  |<- 200 { token, roles } + Set-Cookie: refreshToken (HttpOnly)          |
 ```
 
 The refresh token arrives as a cookie (not a request body) and a rotated one is set on the
@@ -37,34 +37,33 @@ response. A missing cookie yields 401.
 ## 6.3 Generate Meal Plan Suggestions
 
 ```
-Browser                       MealPlanController    MealPlanService            SuggestionService       DB
-  |-- POST /api/meal-plans/suggest -->|                    |                           |               |
-  |                                   |--- generate ------>|                           |               |
-  |                                   |                    |--- getSlotConfig ---------|-------------->|
-  |                                   |                    |<-- slots -----------------|---------------|
-  |                                   |                    |--- getFavorites ----------|-------------->|
-  |                                   |                    |<-- favorites -------------|---------------|
-  |                                   |                    |--- getRecent -------------|-------------->|
-  |                                   |                    |<-- recent ----------------|---------------|
-  |                                   |                    |--- suggest -------------->|               |
-  |                                   |                    |  (filter by ingredient    |               |
-  |                                   |                    |   seasonality,            |               |
-  |                                   |                    |   exclude recent,         |               |
-  |                                   |                    |   mix favorites + others) |               |
-  |                                   |                    |<-- suggestions -----------|               |
-  |                                   |<-- plan draft -----|                           |               |
-  |<-- 200 { plan } ------------------|                    |                           |               |
+Browser                   Meal-plan API            Plan logic             Suggestions                  DB
+  |- POST /api/meal-plans/suggest >                       |                       |                     |
+  |                               |- generate ------------>                       |                     |
+  |                               |                       |- read slot config -------------------------->
+  |                               |                       <- slots -------------------------------------|
+  |                               |                       |- read favorites ---------------------------->
+  |                               |                       <- favorites ---------------------------------|
+  |                               |                       |- read recent history ----------------------->
+  |                               |                       <- recent ------------------------------------|
+  |                               |                       |- rank candidates ----->                     |
+  |                               |                       | (filter by seasonality,                     |
+  |                               |                       |  exclude recent,      |                     |
+  |                               |                       |  mix favorites + others)                    |
+  |                               |                       <- suggestions ---------|                     |
+  |                               <- plan draft ----------|                       |                     |
+  |<- 200 { plan }                |                       |                       |                     |
 ```
 
 ## 6.4 Adjust Meal Plan
 
 ```
-Browser                              MealPlanController  MealPlanService         DB
-  |--- PATCH /api/meal-plans/{id} --------->|                   |                |
-  |   { replace: [slotId], with: recipeId } |                   |                |
-  |                                         |--- update ------->|                |
-  |                                         |                   |--- save ------>|
-  |                                         |                   |<-- ok ---------|
-  |                                         |<-- updated plan --|                |
-  |<-- 200 { plan } ------------------------|                   |                |
+Browser                         Meal-plan API            Plan logic                DB
+  |- PATCH /api/meal-plans/{id} -------->                       |                   |
+  |  { replace: [slotId], with: recipeId }                      |                   |
+  |                                     |- update -------------->                   |
+  |                                     |                       |- save ------------>
+  |                                     |                       <- ok --------------|
+  |                                     <- updated plan --------|                   |
+  |<- 200 { plan }                      |                       |                   |
 ```

--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -3,12 +3,12 @@
 ## 8.1 Authentication and Authorization
 
 - Stateless JWT-based authentication
-- `JWTFilter` intercepts every request, validates the token, and sets the Spring Security context
+- Every request is intercepted, its token validated, and the Spring Security context populated before the request reaches application code
 - Public endpoints: `/api/auth/**` and all static resources
 - All other `/api/**` endpoints require a valid JWT
-- Role-based authorization: every endpoint under `/api/admin/**` additionally requires the `ADMIN` role; enforced in `SecurityConfig` and mirrored in the frontend by `AdminGuard`
+- Role-based authorization: every endpoint under `/api/admin/**` additionally requires the `ADMIN` role; enforced server-side in the security configuration and mirrored by a guard in the frontend router
 - The user's role is included as a claim in the JWT so the frontend can render admin navigation without an extra API call
-- The HMAC-SHA256 signing key is supplied via the `JWT_SECRET` environment variable (no default); a `FailureAnalyzer` surfaces missing or undersized keys as a Spring Boot `APPLICATION FAILED TO START` banner at startup
+- The HMAC-SHA256 signing key is supplied via the `JWT_SECRET` environment variable (no default); a startup check surfaces missing or undersized keys as a Spring Boot `APPLICATION FAILED TO START` banner
 - Two token types are issued: a short-lived **access token** sent on every request and a longer-lived **refresh token** the client exchanges for a new pair at `/api/auth/refresh`. Lifetimes come from `JWT_ACCESS_TTL` (default `PT15M`) and `JWT_REFRESH_TTL` (default `P7D`), each an ISO-8601 duration capped at `P30D`
 - The refresh token is delivered as an `HttpOnly`, `SameSite=Strict` cookie scoped to `/api/auth`, so it is never readable by JavaScript; the access token is returned in the response body and held only in memory on the client. `Secure` is on by default (configurable via `REFRESH_COOKIE_SECURE`; off only for local plain-HTTP development). Logout clears the cookie via `/api/auth/logout`
 - The client derives its login state reactively from the presence of the in-memory access token and renders auth-dependent UI (such as the user menu) from it — login/register affordances while anonymous, logout while authenticated, never both. Because the refresh cookie is invisible to JavaScript, a page reload starts without a client-visible session; the app attempts one silent, non-blocking token refresh at startup to restore it, staying anonymous if none exists. A user-initiated logout always drops local session state, propagates immediately to other open tabs, and is remembered locally so no silent refresh — neither the startup restore nor a 401-triggered one — can resurrect a deliberately ended session; the next successful login lifts that marker. Automatic cleanup after a rejected session sets no such marker, since the user did not ask to leave. If the backend cannot confirm clearing the refresh cookie, the user is sent to a page explaining that the session may still be alive on the device, with instructions to clear the site's cookies and a retry option

--- a/docs/arc42/09-architecture-decisions.md
+++ b/docs/arc42/09-architecture-decisions.md
@@ -16,7 +16,7 @@
 
 **Context:** Meal suggestions require access to the user's favorites, recent meal history, and seasonal data.
 
-**Decision:** Implement suggestion logic in a server-side `SuggestionService` rather than in the frontend.
+**Decision:** Implement suggestion logic server-side rather than in the frontend.
 
 **Consequences:** The algorithm has direct access to all required data without extra API calls. The logic can be tested with unit tests against the service. The frontend remains a thin presentation layer.
 
@@ -34,8 +34,8 @@
 
 **Status:** Accepted
 
-**Context:** Administrators need to curate the shared recipe/ingredient library and manage user accounts (e.g. promote to admin, disable, delete). The existing `Role` enum already distinguishes `USER` and `ADMIN`.
+**Context:** Administrators need to curate the shared recipe/ingredient library and manage user accounts (e.g. promote to admin, disable, delete). The role model already distinguishes `USER` and `ADMIN`.
 
-**Decision:** Ship the administration UI as an `/admin` area inside the same Angular SPA, backed by dedicated REST endpoints under `/api/admin/**` that require the `ADMIN` role. Admin endpoints delegate to the existing domain services (`UserService`, `RecipeService`, `IngredientService`) rather than introducing parallel data-access code.
+**Decision:** Ship the administration UI as an `/admin` area inside the same Angular SPA, backed by dedicated REST endpoints under `/api/admin/**` that require the `ADMIN` role. Admin endpoints delegate to the existing user, recipe, and ingredient domain services rather than introducing parallel data-access code.
 
-**Consequences:** One deployment, one codebase, one auth mechanism. Role-based access control is enforced in `SecurityConfig` and in an `AdminGuard` on the frontend. Admin operations share validation, mapping, and persistence with the regular endpoints, so behavior stays consistent. The downside is that a compromised admin account has full access through the same UI as normal users -- acceptable for a single-operator deployment.
+**Consequences:** One deployment, one codebase, one auth mechanism. Role-based access control is enforced server-side in the security configuration and by a guard in the frontend router. Admin operations share validation, mapping, and persistence with the regular endpoints, so behavior stays consistent. The downside is that a compromised admin account has full access through the same UI as normal users -- acceptable for a single-operator deployment.


### PR DESCRIPTION
Documentation-only changes, in two commits.

## arc42: describe capabilities instead of class names

The arc42 docs referenced concrete implementation classes (and some method names), which rot under refactoring and steer readers toward implementation detail over architectural intent. Each occurrence is rewritten to describe behaviour, contracts, and capabilities:

- **Building-block view** — both Level-2 diagrams now list each module's capabilities, keeping the package structure and REST path contracts.
- **Runtime view** — sequence-diagram lanes are roles (Auth API, Tokens, Plan logic, Suggestions) and arrows are behaviour, not class/method names.
- **Crosscutting concepts & ADRs** — filter/config/guard/service/analyzer references reworded to the behaviour they describe. Domain-model entities and role values stay, as they are domain concepts.

A grep for implementation identifiers across `docs/arc42/` comes back clean.

Closes #168

## Add project README + dedupe config from CLAUDE.md

Adds a top-level README aimed at end users: short description, how to run the published container image, the one-time database/user setup, and a full table of configuration environment variables with defaults and which are required.

With the operator-facing config now in the README (and `application.yaml` as the source of truth), the duplicated environment-variable reference is dropped from CLAUDE.md, keeping only terse auth behavioural hints and pointers to the canonical sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)