### PR TITLE
ci: add two Mistral code-review workflows (bake-off)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          hash=$(gh pr diff "${{ github.event.pull_request.number }}" | sha256sum | cut -d' ' -f1)
+          set -euo pipefail
+          diff=$(gh pr diff "${{ github.event.pull_request.number }}")
+          hash=$(printf '%s' "$diff" | sha256sum | cut -d' ' -f1)
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
       - name: Look up cache for this diff
@@ -48,10 +50,6 @@ jobs:
         with:
           path: .claude-review-marker
           key: claude-review-pr-${{ github.event.pull_request.number }}-${{ steps.diff-hash.outputs.hash }}
-
-      - name: Mark this diff as reviewed
-        if: steps.diff-cache.outputs.cache-hit != 'true'
-        run: touch .claude-review-marker
 
       - name: Run Claude Code Review
         if: steps.diff-cache.outputs.cache-hit != 'true'
@@ -88,4 +86,10 @@ jobs:
             --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      # Mark the diff reviewed only after a successful review, so a failed run isn't
+      # cached as "done" — it will be retried on the next run of the same diff.
+      - name: Mark this diff as reviewed
+        if: steps.diff-cache.outputs.cache-hit != 'true'
+        run: touch .claude-review-marker
 

--- a/.github/workflows/mistral-custom-review.yml
+++ b/.github/workflows/mistral-custom-review.yml
@@ -1,0 +1,112 @@
+name: Mistral Review (custom)
+
+# Experimental — a self-contained Mistral reviewer (codestral-latest) that depends on
+# no third-party action: gh pr diff -> Mistral chat API -> gh pr comment. The API key
+# and write token never leave steps we control. Runs in parallel with
+# mistral-pr-agent-review.yml for comparison; delete the loser once the bake-off ends.
+#
+# Requires a MISTRAL_API_KEY repository secret. Uses the `pull_request` trigger, so PRs
+# from forks (which don't receive secrets) are not reviewed — that's intentional.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  custom-mistral-review:
+    # Skip dependency-bump PRs from dependabot — they don't need an opinionated review.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Compute PR diff hash
+        id: diff-hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          diff=$(gh pr diff "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}")
+          hash=$(printf '%s' "$diff" | sha256sum | cut -d' ' -f1)
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+
+      # Skip when this exact diff was already reviewed. Key namespaced per reviewer so the
+      # parallel PR-Agent workflow can't satisfy this cache and make us skip by mistake.
+      - name: Look up cache for this diff
+        id: diff-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .mistral-custom-marker
+          key: mistral-custom-pr-${{ github.event.pull_request.number }}-${{ steps.diff-hash.outputs.hash }}
+
+      - name: Review with Mistral (codestral-latest)
+        if: steps.diff-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO")
+          if [ -z "$diff" ]; then
+            echo "Empty diff; nothing to review."
+            exit 0
+          fi
+          title=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
+
+          # Guard against very large diffs overflowing the model context.
+          max_chars=180000
+          if [ "${#diff}" -gt "$max_chars" ]; then
+            diff="${diff:0:$max_chars}"$'\n\n[diff truncated for length]'
+          fi
+
+          system_prompt='You are a senior software engineer reviewing a GitHub pull request. You receive a unified diff from a repository pull request. Review ONLY the changes shown in the diff.
+
+          Report every problem you find: correctness bugs, security vulnerabilities, and design or maintainability issues. For each finding give the file, the approximate line, a one-line description, and a brief suggested fix.
+
+          Format as Markdown with no preamble: one sentence of overall summary, then a bullet list of findings, each prefixed with a severity marker (HIGH / MEDIUM / LOW). If you find no issues, say so in one short sentence.'
+          user_content=$(printf 'Pull request title: %s\n\nReview this unified diff:\n\n%s' "$title" "$diff")
+
+          # Build the request body with jq so the diff is safely JSON-escaped.
+          request=$(jq -n \
+            --arg sys "$system_prompt" \
+            --arg user "$user_content" \
+            '{model: "codestral-latest",
+              temperature: 0.2,
+              messages: [
+                {role: "system", content: $sys},
+                {role: "user", content: $user}
+              ]}')
+
+          response=$(curl -sS --fail-with-body \
+            -X POST https://api.mistral.ai/v1/chat/completions \
+            -H "Authorization: Bearer $MISTRAL_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$request")
+
+          review=$(printf '%s' "$response" | jq -r '.choices[0].message.content // empty')
+          if [ -z "$review" ]; then
+            echo "No review content returned. Raw response:"
+            printf '%s\n' "$response"
+            exit 1
+          fi
+
+          {
+            echo "## 🤖 Mistral review · codestral-latest"
+            echo "<sub>Automated review via the custom workflow (experimental).</sub>"
+            echo
+            printf '%s\n' "$review"
+          } > review.md
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file review.md
+
+      # Mark the diff reviewed only after a successful review, so a failed run isn't
+      # cached as "done" — it will be retried on the next run of the same diff.
+      - name: Mark this diff as reviewed
+        if: steps.diff-cache.outputs.cache-hit != 'true'
+        run: touch .mistral-custom-marker

--- a/.github/workflows/mistral-pr-agent-review.yml
+++ b/.github/workflows/mistral-pr-agent-review.yml
@@ -1,0 +1,74 @@
+name: Mistral Review (PR-Agent)
+
+# Experimental — evaluating PR-Agent with Mistral's codestral-latest as a reviewer
+# alongside the Claude review. Runs in parallel with mistral-custom-review.yml so
+# their output can be compared; delete the loser once the bake-off concludes.
+#
+# Requires a MISTRAL_API_KEY repository secret. Like the Claude review, this uses
+# the `pull_request` trigger, so PRs from forks (which don't receive secrets) are
+# not reviewed — that's intentional.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  pr-agent-review:
+    # Skip dependency-bump PRs from dependabot — they don't need an opinionated review.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Compute PR diff hash
+        id: diff-hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          diff=$(gh pr diff "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}")
+          hash=$(printf '%s' "$diff" | sha256sum | cut -d' ' -f1)
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+
+      # Skip when this exact diff was already reviewed (e.g. a rebase/force-push that
+      # leaves the diff unchanged). The key is namespaced per reviewer so the parallel
+      # custom-Mistral workflow can't satisfy this cache and make us skip by mistake.
+      - name: Look up cache for this diff
+        id: diff-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .mistral-pr-agent-marker
+          key: mistral-pr-agent-pr-${{ github.event.pull_request.number }}-${{ steps.diff-hash.outputs.hash }}
+
+      - name: Run PR-Agent review
+        if: steps.diff-cache.outputs.cache-hit != 'true'
+        uses: the-pr-agent/pr-agent@85178bef87b7a03081cd30592a5aad100284f9a7 # v0.37.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          # Route through LiteLLM to Mistral's code-specialized model.
+          config.model: "mistral/codestral-latest"
+          config.fallback_models: '["mistral/codestral-latest"]'
+          # Mistral models aren't in PR-Agent's built-in token-limit map, so set it explicitly.
+          config.custom_model_max_tokens: "128000"
+          # Review only — don't rewrite the PR description or push code suggestions, to keep
+          # the comparison focused on review output.
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "false"
+          github_action_config.auto_improve: "false"
+          # Also re-review on new pushes (PR-Agent omits "synchronize" by default).
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          # Post a fresh review comment on every run instead of editing the previous one in
+          # place, so each review is preserved for the bake-off record.
+          pr_reviewer.persistent_comment: "false"
+          pr_reviewer.final_update_message: "false"
+
+      # Mark the diff reviewed only after a successful review, so a failed run isn't
+      # cached as "done" — it will be retried on the next run of the same diff.
+      - name: Mark this diff as reviewed
+        if: steps.diff-cache.outputs.cache-hit != 'true'
+        run: touch .mistral-pr-agent-marker


### PR DESCRIPTION
Adds two PR-review workflows, both on Mistral `codestral-latest`, to run **alongside** the existing Claude review so their output and cost can be compared. This PR is itself the first test bed — opening it triggers all three reviewers.

## What's added

- **`mistral-pr-agent-review.yml`** — the maintained PR-Agent action (`the-pr-agent/pr-agent`, pinned to v0.37.0 `85178be`), routed to Mistral via LiteLLM. Review-only (`auto_describe`/`auto_improve` off). `config.custom_model_max_tokens` set because Mistral isn't in PR-Agent's built-in token map.
- **`mistral-custom-review.yml`** — a self-contained reviewer depending on no third-party action: `gh pr diff` → Mistral chat API → `gh pr comment`. The API key and write token stay in steps we control.

## Safety scaffolding (mirrors the Claude workflow)

- `pull_request` trigger (not `pull_request_target`); fork PRs receive no secrets and are therefore skipped — intentional.
- Dependabot PRs skipped.
- Per-reviewer **namespaced** diff-hash cache, so an unchanged diff isn't re-reviewed and the two workflows can't satisfy each other's cache.

## Notes for review

- Requires the `MISTRAL_API_KEY` repository secret (added).
- PR-Agent permissions are set least-privilege (`contents: read`); their docs suggest `contents: write`. If the action errors on a permission, that's the first thing to bump.
- The point of this PR is the **bake-off**: compare the PR-Agent vs. custom output here, then delete the loser's workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)