### PR TITLE
Admin area shell — guard, layout, nav link

### DIFF
--- a/docs/arc42/05-building-block-view.md
+++ b/docs/arc42/05-building-block-view.md
@@ -85,13 +85,13 @@ src/main/webapp/app/
 |    Suggestion handling                         |
 |    API communication                           |
 |                                                |
-|  admin/ (planned)                              |
+|  admin/                                        |
 |    Admin area layout and navigation            |
-|    User list and edit                          |
-|    Recipe list and edit                        |
-|    Ingredient list and edit                    |
 |    Route guard restricting area to ADMIN role  |
-|    API communication                           |
+|    User list and edit (planned)                |
+|    Recipe list and edit (planned)              |
+|    Ingredient list and edit (planned)          |
+|    API communication (planned)                 |
 |                                                |
 |  utility/                                      |
 |    Browser storage                             |

--- a/src/main/webapp/app/admin/admin-guard.spec.ts
+++ b/src/main/webapp/app/admin/admin-guard.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { signal, WritableSignal } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  provideRouter,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { AuthService } from '../security/auth.service';
+import { adminGuard } from './admin-guard';
+
+describe('adminGuard', () => {
+  let isAdmin: WritableSignal<boolean>;
+
+  const run = () =>
+    TestBed.runInInjectionContext(() =>
+      adminGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+  beforeEach(() => {
+    isAdmin = signal(false);
+
+    TestBed.configureTestingModule({
+      providers: [provideRouter([]), { provide: AuthService, useValue: { isAdmin } }],
+    });
+  });
+
+  it('admits an admin', () => {
+    isAdmin.set(true);
+
+    expect(run()).toBe(true);
+  });
+
+  it('redirects a non-admin to the home page', () => {
+    const result = run();
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect((result as UrlTree).toString()).toBe('/');
+  });
+});

--- a/src/main/webapp/app/admin/admin-guard.ts
+++ b/src/main/webapp/app/admin/admin-guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../security/auth.service';
+
+/**
+ * Restricts {@code /admin} routes to signed-in administrators. Non-admins (including anonymous
+ * visitors) are redirected to the home page. This is a UX gate only; the backend independently
+ * enforces authorization on every admin API call.
+ */
+export const adminGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return authService.isAdmin() || router.parseUrl('/');
+};

--- a/src/main/webapp/app/admin/admin-shell.html
+++ b/src/main/webapp/app/admin/admin-shell.html
@@ -1,0 +1,17 @@
+<mat-sidenav-container class="admin-shell">
+  <mat-sidenav mode="side" opened>
+    <mat-nav-list>
+      <a
+        mat-list-item
+        routerLink="users"
+        routerLinkActive="active-link"
+        data-test-id="adminNavUsers"
+      >
+        Benutzer
+      </a>
+    </mat-nav-list>
+  </mat-sidenav>
+  <mat-sidenav-content class="admin-content">
+    <router-outlet></router-outlet>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/main/webapp/app/admin/admin-shell.scss
+++ b/src/main/webapp/app/admin/admin-shell.scss
@@ -1,0 +1,7 @@
+.admin-shell {
+  min-height: 70vh;
+}
+
+.admin-content {
+  padding: 1rem;
+}

--- a/src/main/webapp/app/admin/admin-shell.spec.ts
+++ b/src/main/webapp/app/admin/admin-shell.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { AdminShell } from './admin-shell';
+
+describe('AdminShell', () => {
+  let fixture: ComponentFixture<AdminShell>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminShell],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminShell);
+    await fixture.whenStable();
+  });
+
+  it('links to the users page', () => {
+    const link: HTMLAnchorElement = fixture.nativeElement.querySelector(
+      '[data-test-id="adminNavUsers"]',
+    );
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toContain('users');
+    expect(link.textContent).toContain('Benutzer');
+  });
+
+  it('renders an outlet for the child pages', () => {
+    expect(fixture.nativeElement.querySelector('router-outlet')).toBeTruthy();
+  });
+});

--- a/src/main/webapp/app/admin/admin-shell.ts
+++ b/src/main/webapp/app/admin/admin-shell.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatListItem, MatNavList } from '@angular/material/list';
+import { MatSidenav, MatSidenavContainer, MatSidenavContent } from '@angular/material/sidenav';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-admin-shell',
+  imports: [
+    MatSidenavContainer,
+    MatSidenav,
+    MatSidenavContent,
+    MatNavList,
+    MatListItem,
+    RouterLink,
+    RouterLinkActive,
+    RouterOutlet,
+  ],
+  templateUrl: './admin-shell.html',
+  styleUrl: './admin-shell.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminShell {}

--- a/src/main/webapp/app/admin/users/admin-users.html
+++ b/src/main/webapp/app/admin/users/admin-users.html
@@ -1,0 +1,2 @@
+<h1>Benutzer</h1>
+<p>Die Benutzerverwaltung folgt in Kürze.</p>

--- a/src/main/webapp/app/admin/users/admin-users.scss
+++ b/src/main/webapp/app/admin/users/admin-users.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/main/webapp/app/admin/users/admin-users.spec.ts
+++ b/src/main/webapp/app/admin/users/admin-users.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminUsers } from './admin-users';
+
+describe('AdminUsers', () => {
+  let fixture: ComponentFixture<AdminUsers>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminUsers],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminUsers);
+    await fixture.whenStable();
+  });
+
+  it('shows the users heading', () => {
+    const heading: HTMLElement = fixture.nativeElement.querySelector('h1');
+    expect(heading.textContent).toContain('Benutzer');
+  });
+});

--- a/src/main/webapp/app/admin/users/admin-users.ts
+++ b/src/main/webapp/app/admin/users/admin-users.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-admin-users',
+  templateUrl: './admin-users.html',
+  styleUrl: './admin-users.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminUsers {}

--- a/src/main/webapp/app/app.html
+++ b/src/main/webapp/app/app.html
@@ -3,6 +3,9 @@
   <!--    <mat-icon>menu</mat-icon>-->
   <!--  </button>-->
   <span data-test-id="appTitle">Rezepte</span>
+  @if (isAdmin()) {
+    <a mat-button routerLink="admin" data-test-id="adminLink">Admin</a>
+  }
   <span class="spacer"></span>
   <button matIconButton data-test-id="profileIcon" [matMenuTriggerFor]="userMenu">
     <mat-icon>person</mat-icon>

--- a/src/main/webapp/app/app.routes.spec.ts
+++ b/src/main/webapp/app/app.routes.spec.ts
@@ -1,0 +1,26 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+
+import { routes } from './app.routes';
+import { AuthService } from './security/auth.service';
+
+describe('admin routes', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes),
+        { provide: AuthService, useValue: { isAdmin: signal(true) } },
+      ],
+    });
+  });
+
+  it('redirects an unknown /admin/* path to the users page', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/admin/nonsense');
+
+    expect(TestBed.inject(Router).url).toBe('/admin/users');
+  });
+});

--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -1,4 +1,7 @@
 import { Routes } from '@angular/router';
+import { adminGuard } from './admin/admin-guard';
+import { AdminShell } from './admin/admin-shell';
+import { AdminUsers } from './admin/users/admin-users';
 import { Login } from './security/login/login';
 import { LogoutFailed } from './security/logout-failed/logout-failed';
 import { Register } from './security/register/register';
@@ -24,5 +27,20 @@ export const routes: Routes = [
     title: 'Rezepte - Registrierung erfolgreich',
     path: 'register/success',
     component: RegisterSuccess,
+  },
+  {
+    title: 'Rezepte - Administration',
+    path: 'admin',
+    component: AdminShell,
+    canActivate: [adminGuard],
+    children: [
+      { path: '', redirectTo: 'users', pathMatch: 'full' },
+      {
+        title: 'Rezepte - Benutzer',
+        path: 'users',
+        component: AdminUsers,
+      },
+      { path: '**', redirectTo: 'users' },
+    ],
   },
 ];

--- a/src/main/webapp/app/app.spec.ts
+++ b/src/main/webapp/app/app.spec.ts
@@ -9,11 +9,12 @@ describe('App', () => {
   let fixture: ComponentFixture<App>;
   let authServiceSpy: Mocked<Pick<AuthService, 'logout'>> & {
     isLoggedIn: WritableSignal<boolean>;
+    isAdmin: WritableSignal<boolean>;
   };
   let navigateSpy: MockInstance;
 
   beforeEach(async () => {
-    authServiceSpy = { isLoggedIn: signal(false), logout: vi.fn() };
+    authServiceSpy = { isLoggedIn: signal(false), isAdmin: signal(false), logout: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [App],
@@ -59,6 +60,25 @@ describe('App', () => {
     expect(menuItem('logout')).toBeTruthy();
     expect(menuItem('register')).toBeNull();
     expect(menuItem('login')).toBeNull();
+  });
+
+  const adminLink = () =>
+    fixture.nativeElement.querySelector('[data-test-id="adminLink"]') as HTMLAnchorElement | null;
+
+  it('hides the admin link from non-admins', () => {
+    authServiceSpy.isAdmin.set(false);
+    fixture.detectChanges();
+
+    expect(adminLink()).toBeNull();
+  });
+
+  it('shows the admin link to admins', () => {
+    authServiceSpy.isAdmin.set(true);
+    fixture.detectChanges();
+
+    const link = adminLink();
+    expect(link).toBeTruthy();
+    expect(link!.getAttribute('href')).toContain('admin');
   });
 
   it('logs out via the user menu and routes to the login page', async () => {

--- a/src/main/webapp/app/app.ts
+++ b/src/main/webapp/app/app.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIcon } from '@angular/material/icon';
-import { MatIconButton } from '@angular/material/button';
+import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { Router, RouterLink, RouterOutlet } from '@angular/router';
 import { AuthService } from './security/auth.service';
@@ -11,6 +11,7 @@ import { AuthService } from './security/auth.service';
   imports: [
     MatToolbar,
     MatIcon,
+    MatButton,
     MatIconButton,
     MatMenu,
     MatMenuTrigger,
@@ -27,6 +28,7 @@ export class App {
   private router = inject(Router);
 
   protected readonly loggedIn = this.authService.isLoggedIn;
+  protected readonly isAdmin = this.authService.isAdmin;
 
   async logout(): Promise<void> {
     const confirmed = await this.authService.logout();

--- a/src/main/webapp/app/security/auth.service.spec.ts
+++ b/src/main/webapp/app/security/auth.service.spec.ts
@@ -284,6 +284,57 @@ describe('AuthService', () => {
     expect(service.isLoggedIn()).toBe(false);
   });
 
+  it('is not admin before authenticating', () => {
+    expect(service.isAdmin()).toBe(false);
+  });
+
+  it('exposes an admin signal that follows a login carrying the ADMIN role', async () => {
+    const promise = service.login({ usernameOrEmail: 'root', password: 'pw' });
+    httpMock.expectOne('/api/auth/login').flush({ token: 'access-1', roles: ['USER', 'ADMIN'] });
+    expect(await promise).toBe(true);
+
+    expect(service.isAdmin()).toBe(true);
+  });
+
+  it('stays non-admin after a login that carries no ADMIN role', async () => {
+    const promise = service.login({ usernameOrEmail: 'alice', password: 'pw' });
+    httpMock.expectOne('/api/auth/login').flush({ token: 'access-1', roles: ['USER'] });
+    expect(await promise).toBe(true);
+
+    expect(service.isAdmin()).toBe(false);
+  });
+
+  it('restores the admin state from the refresh cookie', async () => {
+    const refreshed = firstValueFrom(service.refresh());
+    httpMock.expectOne('/api/auth/refresh').flush({ token: 'restored', roles: ['ADMIN'] });
+    await refreshed;
+
+    expect(service.isAdmin()).toBe(true);
+  });
+
+  it('drops the admin state when the local session is cleared', async () => {
+    const refreshed = firstValueFrom(service.refresh());
+    httpMock.expectOne('/api/auth/refresh').flush({ token: 'access-1', roles: ['ADMIN'] });
+    await refreshed;
+    expect(service.isAdmin()).toBe(true);
+
+    service.clearLocalSession();
+
+    expect(service.isAdmin()).toBe(false);
+  });
+
+  it('drops the admin state on logout', async () => {
+    const promise = service.login({ usernameOrEmail: 'root', password: 'pw' });
+    httpMock.expectOne('/api/auth/login').flush({ token: 'access-1', roles: ['ADMIN'] });
+    await promise;
+    expect(service.isAdmin()).toBe(true);
+
+    service.logout();
+    httpMock.expectOne('/api/auth/logout').flush(null);
+
+    expect(service.isAdmin()).toBe(false);
+  });
+
   it('logout drops the token but resolves false when the backend call fails', async () => {
     const refreshed = firstValueFrom(service.refresh());
     httpMock.expectOne('/api/auth/refresh').flush({ token: 'access-1', roles: ['USER'] });

--- a/src/main/webapp/app/security/auth.service.ts
+++ b/src/main/webapp/app/security/auth.service.ts
@@ -63,7 +63,14 @@ export class AuthService {
   // from the refresh cookie. A signal, so auth-state-dependent UI reacts to it.
   private readonly accessToken = signal<string | null>(null);
 
+  // The user's roles, refreshed from every login and refresh response (the access token holds the
+  // authoritative copy server-side; this is only a UI hint for gating admin-only navigation). Like
+  // the token it lives in memory and starts empty after a reload until restoreSession() runs.
+  private readonly roles = signal<readonly string[]>([]);
+
   readonly isLoggedIn = computed(() => this.accessToken() !== null);
+
+  readonly isAdmin = computed(() => this.roles().includes('ADMIN'));
 
   // Holds the in-flight refresh so a burst of simultaneous 401s (e.g. several requests firing
   // after a reload) shares one POST /api/auth/refresh instead of each rotating the cookie. Reset
@@ -93,6 +100,7 @@ export class AuthService {
         this.http.post<LoginResponse>('/api/auth/login', credentials, { withCredentials: true }),
       );
       this.accessToken.set(response.token);
+      this.roles.set(response.roles);
       this.localStorage.removeItem(AuthService.LOGGED_OUT_KEY);
       return true;
     } catch (error) {
@@ -122,6 +130,7 @@ export class AuthService {
   // ask to leave, so a still-valid session may be silently restored on the next load.
   clearLocalSession(): void {
     this.accessToken.set(null);
+    this.roles.set([]);
   }
 
   refresh(): Observable<string> {
@@ -132,18 +141,21 @@ export class AuthService {
     this.refreshInFlight$ ??= this.http
       .post<LoginResponse>('/api/auth/refresh', {}, { withCredentials: true })
       .pipe(
-        map((response) => response.token),
         // Re-checked mid-stream: a logout performed while this refresh was in flight (in this tab
-        // or, via the shared marker, in another one) must win. Erroring discards the late token
-        // for every consumer — it is neither stored below nor handed to callers such as the
-        // interceptor's retry.
-        map((token) => {
+        // or, via the shared marker, in another one) must win. Erroring discards the late response
+        // for every consumer — neither token nor roles are stored below, and the token is not
+        // handed to callers such as the interceptor's retry.
+        map((response) => {
           if (this.localStorage.getItem(AuthService.LOGGED_OUT_KEY)) {
             throw AuthService.loggedOutError();
           }
-          return token;
+          return response;
         }),
-        tap((token) => this.accessToken.set(token)),
+        tap((response) => {
+          this.accessToken.set(response.token);
+          this.roles.set(response.roles);
+        }),
+        map((response) => response.token),
         finalize(() => (this.refreshInFlight$ = null)),
         shareReplay(1),
       );


### PR DESCRIPTION
First slice of Phase 1 (User Administration): a gated `/admin` area, before any data is shown.

## Changes
- **AuthService**: tracks roles from login and refresh responses and exposes a reactive `isAdmin` signal; roles are cleared with the local session. The late-refresh-after-logout guard now covers roles as well.
- **adminGuard** (`CanActivateFn`): allows `/admin/**` only for admins, redirecting everyone else to `/`. UX-only gate — the backend still enforces authorization on every admin API call.
- **admin-shell**: `mat-sidenav` layout with a "Benutzer" nav entry and a child outlet; `/admin` redirects to `/admin/users`.
- **admin-users**: placeholder page, filled by the next slice.
- **Toolbar**: an "Admin" link shown only to admins, reactive on auth state.
- **arc42**: `05-building-block-view.md` drops "(planned)" from the now-shipped admin shell/guard, keeping it on the unbuilt management pages.

## Known limitation
A hard navigation directly to `/admin` (bookmark/refresh) redirects even a real admin to `/`, because the guard reads `isAdmin()` synchronously before async session restore repopulates roles. In-app navigation works (session is live). Out of scope here; reasonable follow-up.

## Test plan
- `npm run test:ci` — 84 pass (12 new), `lint:check` + `format:check` clean.
- Browser-verified end-to-end: non-admin has no Admin link and `/admin` redirects to `/`; after promoting a user to ADMIN, the Admin link appears and `/admin` → `/admin/users` shows the shell.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)