### PR TITLE
ci(review): switch Mistral reviewers to mistral-large-latest

### DIFF
--- a/.github/workflows/mistral-custom-review.yml
+++ b/.github/workflows/mistral-custom-review.yml
@@ -1,6 +1,6 @@
 name: Mistral Review (custom)
 
-# Experimental — a self-contained Mistral reviewer (codestral-latest) that depends on
+# Experimental — a self-contained Mistral reviewer (mistral-large-latest) that depends on
 # no third-party action: gh pr diff -> Mistral chat API -> gh pr comment. The API key
 # and write token never leave steps we control. Runs in parallel with
 # mistral-pr-agent-review.yml for comparison; delete the loser once the bake-off ends.
@@ -42,7 +42,7 @@ jobs:
           path: .mistral-custom-marker
           key: mistral-custom-pr-${{ github.event.pull_request.number }}-${{ steps.diff-hash.outputs.hash }}
 
-      - name: Review with Mistral (codestral-latest)
+      - name: Review with Mistral (mistral-large-latest)
         if: steps.diff-cache.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -76,7 +76,7 @@ jobs:
           request=$(jq -n \
             --arg sys "$system_prompt" \
             --arg user "$user_content" \
-            '{model: "codestral-latest",
+            '{model: "mistral-large-latest",
               temperature: 0.2,
               messages: [
                 {role: "system", content: $sys},
@@ -97,7 +97,7 @@ jobs:
           fi
 
           {
-            echo "## 🤖 Mistral review · codestral-latest"
+            echo "## 🤖 Mistral review · mistral-large-latest"
             echo "<sub>Automated review via the custom workflow (experimental).</sub>"
             echo
             printf '%s\n' "$review"

--- a/.github/workflows/mistral-pr-agent-review.yml
+++ b/.github/workflows/mistral-pr-agent-review.yml
@@ -1,6 +1,6 @@
 name: Mistral Review (PR-Agent)
 
-# Experimental — evaluating PR-Agent with Mistral's codestral-latest as a reviewer
+# Experimental — evaluating PR-Agent with Mistral's mistral-large-latest as a reviewer
 # alongside the Claude review. Runs in parallel with mistral-custom-review.yml so
 # their output can be compared; delete the loser once the bake-off concludes.
 #
@@ -50,9 +50,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          # Route through LiteLLM to Mistral's code-specialized model.
-          config.model: "mistral/codestral-latest"
-          config.fallback_models: '["mistral/codestral-latest"]'
+          # Route through LiteLLM to Mistral's flagship reasoning model.
+          config.model: "mistral/mistral-large-latest"
+          config.fallback_models: '["mistral/mistral-large-latest"]'
           # Mistral models aren't in PR-Agent's built-in token-limit map, so set it explicitly.
           config.custom_model_max_tokens: "128000"
           # Review only — don't rewrite the PR description or push code suggestions, to keep


### PR DESCRIPTION
## Summary

Switches both Mistral PR reviewers from `codestral-latest` to `mistral-large-latest`:

- **Custom** (`mistral-custom-review.yml`) — request body `model`, plus step name and the comment banner posted on the PR.
- **PR-Agent** (`mistral-pr-agent-review.yml`) — `config.model` and `config.fallback_models`. `custom_model_max_tokens: "128000"` stays valid.

## Why

Across the bake-off on #234, Codestral underperformed on review substance — false positives (including HIGH-severity ones on real diffs), severity miscalibration, and run-to-run inconsistency. This moves both reviewers to Mistral's flagship reasoning model to evaluate whether a stronger model earns a permanent slot, per the Phase 2 / follow-up plan on #234.

Note: this changes the model mid-bake-off, so earlier Codestral findings aren't apples-to-apples with what these reviewers post going forward — to be noted in the #234 record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)