### PR TITLE
ci(review): update reviewer models

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -81,7 +81,7 @@ jobs:
             reviewer, e.g. `## pr-code-reviewer`, `## web-security-reviewer`. Do
             not merge them into a single comment — keep each review distinct.
           claude_args: >-
-            --model opus
+            --model fable
             --max-turns 25
             --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
Updates the models used by the automated PR reviewers:

- **Claude review workflow**: back to the `fable` tier alias. The 400 that forced the pin to `opus` (dd1ac4d) predated Fable 5's general availability, so the alias should resolve again; if it recurs, reverting to `opus` is a one-line rollback.
- **Mistral reviewers** (PR-Agent + custom): `codestral` → `mistral-large-latest`, routing both through Mistral's flagship model for the bake-off (#234).

Note: this PR touches `claude-code-review.yml`, so the Claude review check will fail by design; the model switch gets verified by triggering `@claude` on a subsequent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)