### PR TITLE
ci: fix pr-agent pin and guard Claude workflows against background-work teardown

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,7 +61,10 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: |
             Review PR ${{ github.repository }}#${{ github.event.pull_request.number }}
-            by delegating to TWO subagents in parallel via the Task tool. Each
+            by delegating to TWO subagents in parallel via the Task tool. Run
+            them synchronously (`run_in_background: false`) — background
+            subagents die when this CI job ends, so do not end your turn until
+            both subagents have finished and both comments are posted. Each
             subagent is defined in .claude/agents/ and must be invoked with its
             exact name as `subagent_type`:
 
@@ -84,6 +87,7 @@ jobs:
             --model fable
             --max-turns 25
             --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --append-system-prompt "You run in an ephemeral CI job that terminates the moment your turn ends. Never launch background subagents or background shell tasks — run everything synchronously (run_in_background: false) and do not end your turn while any delegated work is still pending."
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,8 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          claude_args: >-
+            --append-system-prompt "You run in an ephemeral CI job that terminates the moment your turn ends. Never launch background subagents or background shell tasks — run everything synchronously (run_in_background: false) and do not end your turn while any delegated work is still pending."
 

--- a/.github/workflows/mistral-pr-agent-review.yml
+++ b/.github/workflows/mistral-pr-agent-review.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run PR-Agent review
         if: steps.diff-cache.outputs.cache-hit != 'true'
-        uses: the-pr-agent/pr-agent@65715b0187fd2a8ede2a3b2f9952990e9e71121e # v0.38.0
+        uses: the-pr-agent/pr-agent@bd09b6cf89c6d6f3d16b159fa7603fa0e7768cf2 # v0.38.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}


### PR DESCRIPTION
Three related CI review fixes:

**Repoint pr-agent pin to the actual v0.38.0 tag commit.** The previous bump (6080e54) pinned `65715b0`, a commit no tag points to — upstream's release automation moved the `v0.38.0` tag to `bd09b6c` afterwards. When a SHA pin matches no release tag, Dependabot assumes a deliberate branch pin and starts proposing head-of-main commits (see #261) instead of releases. Repointing to the tagged commit restores release-to-release bumps. #261 is left open; Dependabot will close it on its own once this lands.

**Run review subagents synchronously.** The current Claude Code runtime launches Task subagents in the background by default; the orchestrator turn ends right after spawning them and the action tears the runner down before the reviewers post their comments — a green check with no review (first observed on this PR's initial run). The review prompt now instructs the orchestrator to run both subagents synchronously and keep its turn open until both comments are posted.

**System-prompt guard in both Claude workflows.** The same teardown risk applies to anything backgrounded in an ephemeral CI job, including free-form `@claude` tasks that decide to delegate on their own. Both `claude.yml` and `claude-code-review.yml` now append a system prompt forbidding background subagents and background shell tasks.

Note: this PR now touches `claude-code-review.yml`, so the claude-review check fails by design from here on; the fixes get verified on the next ordinary PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)