### PR TITLE
feat(admin): show all users in the admin user list

### DIFF
--- a/docs/arc42/05-building-block-view.md
+++ b/docs/arc42/05-building-block-view.md
@@ -48,7 +48,7 @@ ch.ethy.recipes
 |    Plan CRUD, persistence                              |
 |    Meal-suggestion logic                               |
 |                                                        |
-|  admin/ (planned)                                      |
+|  admin/                                                |
 |    Admin endpoints (REST: /api/admin/**)               |
 |    ADMIN role required; reuses domain services         |
 |                                                        |
@@ -88,10 +88,11 @@ src/main/webapp/app/
 |  admin/                                        |
 |    Admin area layout and navigation            |
 |    Route guard restricting area to ADMIN role  |
-|    User list and edit (planned)                |
+|    User list                                   |
+|    User edit (planned)                         |
 |    Recipe list and edit (planned)              |
 |    Ingredient list and edit (planned)          |
-|    API communication (planned)                 |
+|    API communication                           |
 |                                                |
 |  utility/                                      |
 |    Browser storage                             |

--- a/src/main/java/ch/ethy/recipes/admin/AdminUserController.java
+++ b/src/main/java/ch/ethy/recipes/admin/AdminUserController.java
@@ -1,0 +1,23 @@
+package ch.ethy.recipes.admin;
+
+import ch.ethy.recipes.user.UserDto;
+import ch.ethy.recipes.user.UserService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/users")
+public class AdminUserController {
+  private final UserService userService;
+
+  public AdminUserController(UserService userService) {
+    this.userService = userService;
+  }
+
+  @GetMapping
+  public List<UserDto> getAllUsers() {
+    return userService.getAllUsers();
+  }
+}

--- a/src/main/java/ch/ethy/recipes/user/UserDto.java
+++ b/src/main/java/ch/ethy/recipes/user/UserDto.java
@@ -1,3 +1,5 @@
 package ch.ethy.recipes.user;
 
-public record UserDto(long id, String username, String email) {}
+import java.util.Set;
+
+public record UserDto(long id, String username, String email, Set<Role> roles) {}

--- a/src/main/java/ch/ethy/recipes/user/UserService.java
+++ b/src/main/java/ch/ethy/recipes/user/UserService.java
@@ -1,5 +1,7 @@
 package ch.ethy.recipes.user;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -13,14 +15,19 @@ public class UserService {
   }
 
   public List<UserDto> getAllUsers() {
-    return userRepository.findAll().stream()
-        .map(user -> new UserDto(user.getId(), user.getUsername(), user.getEmail()))
-        .toList();
+    return userRepository.findAll().stream().map(UserService::toDto).toList();
   }
 
   public Optional<UserDto> findUser(long id) {
-    return userRepository
-        .findById(id)
-        .map(user -> new UserDto(user.getId(), user.getUsername(), user.getEmail()));
+    return userRepository.findById(id).map(UserService::toDto);
+  }
+
+  private static UserDto toDto(User user) {
+    // EnumSet iterates in declaration order, giving the roles a stable order everywhere they are
+    // serialized; copying also detaches the DTO from the entity's mutable set.
+    EnumSet<Role> roles = EnumSet.noneOf(Role.class);
+    roles.addAll(user.getRoles());
+    return new UserDto(
+        user.getId(), user.getUsername(), user.getEmail(), Collections.unmodifiableSet(roles));
   }
 }

--- a/src/main/webapp/app/admin/admin.service.spec.ts
+++ b/src/main/webapp/app/admin/admin.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    service = TestBed.inject(AdminService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('getUsers fetches the user list from the admin API', async () => {
+    const promise = firstValueFrom(service.getUsers());
+
+    const req = httpMock.expectOne('/api/admin/users');
+    expect(req.request.method).toBe('GET');
+    req.flush([
+      { id: 1, username: 'alice', email: 'alice@example.com', roles: ['USER', 'ADMIN'] },
+      { id: 2, username: 'bob', email: 'bob@example.com', roles: ['USER'] },
+    ]);
+
+    const users = await promise;
+    expect(users).toEqual([
+      { id: 1, username: 'alice', email: 'alice@example.com', roles: ['USER', 'ADMIN'] },
+      { id: 2, username: 'bob', email: 'bob@example.com', roles: ['USER'] },
+    ]);
+  });
+});

--- a/src/main/webapp/app/admin/admin.service.ts
+++ b/src/main/webapp/app/admin/admin.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export interface AdminUser {
+  id: number;
+  username: string;
+  email: string;
+  roles: string[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminService {
+  private http = inject(HttpClient);
+
+  getUsers(): Observable<AdminUser[]> {
+    return this.http.get<AdminUser[]>('/api/admin/users');
+  }
+}

--- a/src/main/webapp/app/admin/users/admin-users.html
+++ b/src/main/webapp/app/admin/users/admin-users.html
@@ -1,2 +1,17 @@
 <h1>Benutzer</h1>
-<p>Die Benutzerverwaltung folgt in Kürze.</p>
+<table mat-table [dataSource]="users()">
+  <ng-container matColumnDef="username">
+    <th mat-header-cell *matHeaderCellDef>Benutzername</th>
+    <td mat-cell *matCellDef="let user">{{ user.username }}</td>
+  </ng-container>
+  <ng-container matColumnDef="email">
+    <th mat-header-cell *matHeaderCellDef>E-Mail</th>
+    <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+  </ng-container>
+  <ng-container matColumnDef="roles">
+    <th mat-header-cell *matHeaderCellDef>Rollen</th>
+    <td mat-cell *matCellDef="let user">{{ user.roles.join(', ') }}</td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="columns"></tr>
+  <tr mat-row *matRowDef="let row; columns: columns"></tr>
+</table>

--- a/src/main/webapp/app/admin/users/admin-users.spec.ts
+++ b/src/main/webapp/app/admin/users/admin-users.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
+import { AdminService } from '../admin.service';
 import { AdminUsers } from './admin-users';
 
 describe('AdminUsers', () => {
@@ -8,6 +10,18 @@ describe('AdminUsers', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AdminUsers],
+      providers: [
+        {
+          provide: AdminService,
+          useValue: {
+            getUsers: () =>
+              of([
+                { id: 1, username: 'alice', email: 'alice@example.com', roles: ['USER', 'ADMIN'] },
+                { id: 2, username: 'bob', email: 'bob@example.com', roles: ['USER'] },
+              ]),
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminUsers);
@@ -17,5 +31,16 @@ describe('AdminUsers', () => {
   it('shows the users heading', () => {
     const heading: HTMLElement = fixture.nativeElement.querySelector('h1');
     expect(heading.textContent).toContain('Benutzer');
+  });
+
+  it('renders one table row per user with username, email and roles', () => {
+    const rows: NodeListOf<HTMLElement> = fixture.nativeElement.querySelectorAll('tr[mat-row]');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain('alice');
+    expect(rows[0].textContent).toContain('alice@example.com');
+    expect(rows[0].textContent).toContain('USER, ADMIN');
+    expect(rows[1].textContent).toContain('bob');
+    expect(rows[1].textContent).toContain('bob@example.com');
+    expect(rows[1].textContent).toContain('USER');
   });
 });

--- a/src/main/webapp/app/admin/users/admin-users.ts
+++ b/src/main/webapp/app/admin/users/admin-users.ts
@@ -1,9 +1,40 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable,
+} from '@angular/material/table';
+import { AdminService } from '../admin.service';
 
 @Component({
   selector: 'app-admin-users',
+  imports: [
+    MatCell,
+    MatCellDef,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatTable,
+  ],
   templateUrl: './admin-users.html',
   styleUrl: './admin-users.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AdminUsers {}
+export class AdminUsers {
+  private adminService = inject(AdminService);
+
+  protected readonly users = toSignal(this.adminService.getUsers(), { initialValue: [] });
+  protected readonly columns = ['username', 'email', 'roles'];
+}

--- a/src/test/java/ch/ethy/recipes/admin/AdminUserControllerTest.java
+++ b/src/test/java/ch/ethy/recipes/admin/AdminUserControllerTest.java
@@ -1,0 +1,65 @@
+package ch.ethy.recipes.admin;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.ethy.recipes.security.JwtService;
+import ch.ethy.recipes.security.TokenVersionService;
+import ch.ethy.recipes.user.Role;
+import ch.ethy.recipes.user.UserDto;
+import ch.ethy.recipes.user.UserService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminUserController.class)
+class AdminUserControllerTest {
+
+  @TestConfiguration
+  static class SecurityTestConfig {
+    @Bean
+    SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+      return http.csrf(AbstractHttpConfigurer::disable)
+          .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .build();
+    }
+  }
+
+  @Autowired private MockMvc mockMvc;
+  @MockitoBean private UserService userService;
+
+  // JWTFilter is pulled into the slice and needs these collaborators.
+  @MockitoBean private JwtService jwtService;
+  @MockitoBean private TokenVersionService tokenVersionService;
+
+  @Test
+  void listsAllUsers() throws Exception {
+    when(userService.getAllUsers())
+        .thenReturn(
+            List.of(
+                new UserDto(1L, "alice", "alice@example.com", Set.of(Role.USER, Role.ADMIN)),
+                new UserDto(2L, "bob", "bob@example.com", Set.of(Role.USER))));
+
+    mockMvc
+        .perform(get("/api/admin/users"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].username").value("alice"))
+        .andExpect(jsonPath("$[0].email").value("alice@example.com"))
+        .andExpect(jsonPath("$[0].roles.length()").value(2))
+        .andExpect(jsonPath("$[1].username").value("bob"))
+        .andExpect(jsonPath("$[1].roles[0]").value("USER"));
+  }
+}

--- a/src/test/java/ch/ethy/recipes/security/JwtBearerAuthorizationTest.java
+++ b/src/test/java/ch/ethy/recipes/security/JwtBearerAuthorizationTest.java
@@ -73,7 +73,7 @@ class JwtBearerAuthorizationTest {
   @BeforeEach
   void stubExistingUser() {
     when(userService.findUser(1L))
-        .thenReturn(Optional.of(new UserDto(1L, "alice", "alice@example.com")));
+        .thenReturn(Optional.of(new UserDto(1L, "alice", "alice@example.com", Set.of(Role.USER))));
     when(tokenVersionService.getCurrentVersion(1L)).thenReturn(0);
   }
 

--- a/src/test/java/ch/ethy/recipes/user/UserServiceTest.java
+++ b/src/test/java/ch/ethy/recipes/user/UserServiceTest.java
@@ -1,0 +1,47 @@
+package ch.ethy.recipes.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UserServiceTest {
+
+  private UserRepository userRepository;
+  private UserService userService;
+
+  @BeforeEach
+  void setUp() {
+    userRepository = mock(UserRepository.class);
+    userService = new UserService(userRepository);
+  }
+
+  @Test
+  void rolesAreReturnedInDeclarationOrder() {
+    User admin = new User();
+    admin.setUsername("alice");
+    admin.setEmail("alice@example.com");
+    admin.addRole(Role.ADMIN);
+    when(userRepository.findAll()).thenReturn(List.of(admin));
+
+    UserDto dto = userService.getAllUsers().getFirst();
+
+    assertEquals(List.of(Role.USER, Role.ADMIN), List.copyOf(dto.roles()));
+  }
+
+  @Test
+  void rolesAreDetachedFromLaterEntityChanges() {
+    User user = new User();
+    user.setUsername("bob");
+    user.setEmail("bob@example.com");
+    when(userRepository.findAll()).thenReturn(List.of(user));
+
+    UserDto dto = userService.getAllUsers().getFirst();
+    user.addRole(Role.ADMIN);
+
+    assertEquals(List.of(Role.USER), List.copyOf(dto.roles()));
+  }
+}


### PR DESCRIPTION
Phase 1 · slice 2 of 7 — first slice showing real data in the admin area.

## Changes

- **Backend**: new `admin` package with `GET /api/admin/users`, delegating to the existing `UserService` (no parallel persistence layer). ADMIN-only via the existing `/api/admin/**` rule in SecurityConfig. `UserDto` now carries the user's roles.
- **Frontend**: `AdminService.getUsers()` with a typed `AdminUser` model; the admin users view renders a read-only Material table (username, email, roles) at `/admin/users`.
- arc42 §5: backend `admin/` block is no longer "(planned)"; frontend admin block lists the user list as shipped.

## Decisions

- The pre-existing `/api/users` controller stays untouched for now.
- The `enabled` column is deferred to #91, which introduces the flag and its toggle together.

## Test plan

- Controller test for the new endpoint (WebMvcTest), service and component specs for the frontend; full suite green.
- Verified end-to-end in the browser: logged in as an admin, `/admin/users` lists all users with their roles.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)