### PR TITLE
Fail and diagnose the Claude review job when no review is posted

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,6 +59,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # Print the SDK output so a failed run's error is visible in the job
+          # log. The default hides it, which leaves an errored review with no
+          # diagnosable cause once the runner is gone.
+          show_full_output: true
           prompt: |
             Review PR ${{ github.repository }}#${{ github.event.pull_request.number }}
             by delegating to TWO subagents in parallel via the Task tool. Run

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -95,9 +95,39 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
-      # Mark the diff reviewed only after a successful review, so a failed run isn't
-      # cached as "done" — it will be retried on the next run of the same diff.
-      - name: Mark this diff as reviewed
+      # The action exits 0 even when the model turn ends in an error, so an
+      # errored review would otherwise leave a green check with no review
+      # posted. Read the execution output and fail the job on an errored run,
+      # echoing the result frame so the cause is visible in the log.
+      - name: Verify the review succeeded
+        id: verify
         if: steps.diff-cache.outputs.cache-hit != 'true'
+        env:
+          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXECUTION_FILE:-}" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "::error::Claude review produced no execution output; treating as a failed review."
+            exit 1
+          fi
+          result=$(jq -c '[.[] | select(.type == "result")] | last' "$EXECUTION_FILE")
+          if [ -z "$result" ] || [ "$result" = "null" ]; then
+            echo "::error::Claude review output has no result frame; treating as a failed review."
+            exit 1
+          fi
+          is_error=$(printf '%s' "$result" | jq -r '.is_error')
+          if [ "$is_error" != "false" ]; then
+            echo "::error::Claude review ended in an error (is_error=$is_error); no review was posted."
+            echo "Result frame:"
+            printf '%s\n' "$result" | jq .
+            exit 1
+          fi
+          echo "Claude review completed successfully."
+
+      # Mark the diff reviewed only after a verified-successful review, so a
+      # failed run isn't cached as "done" — it will be retried on the next run
+      # of the same diff.
+      - name: Mark this diff as reviewed
+        if: steps.diff-cache.outputs.cache-hit != 'true' && steps.verify.outcome == 'success'
         run: touch .claude-review-marker
 


### PR DESCRIPTION
## Summary

The `claude-review` job could report a green ✅ check while posting no review at all (observed on #274). Three defects combined; this fixes all of them.

- **Surface the error.** Set `show_full_output: true` and have the new verify step echo the run's `result` frame. The action otherwise hides the SDK output ("full output hidden for security"), so an errored run left no diagnosable cause once the runner was discarded.
- **Fail the job when the review errors.** The `anthropics/claude-code-action` step exits 0 even when the model turn ends with `is_error: true`. A new **Verify the review succeeded** step reads the action's `execution_file`, and fails the job when the run ended in an error (or produced no result frame) — so a broken review shows up red instead of green.
- **Stop caching failed diffs as "done".** The `Mark this diff as reviewed` step previously guarded only on a cache miss, so a failed run still wrote the marker and cached the diff — making retries/restarts skip the review (exactly what happened when #274 was restarted). It is now gated on the verification passing, so a failed diff is retried on the next run.

## Notes

- A PR that touches `claude-code-review.yml` fails its own `claude-review` check by design (the review runs against the base workflow); that failure here is expected, not a regression.
- Verified locally: the workflow YAML parses, and the verify step's `jq` passes a clean run while failing both observed error modes (`is_error: true` after 3 turns, and the immediate `$0`/1-turn error) as well as a missing result frame.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)