### PR TITLE
Split the review: required Opus code review + best-effort Fable security review

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -1,0 +1,66 @@
+name: Claude review pass
+description: >-
+  Run one Claude Code review pass for a pull request: invoke a single named
+  review subagent on the given model and post its review as a PR comment.
+
+inputs:
+  model:
+    description: Model to run the review on (e.g. fable, opus).
+    required: true
+  reviewer:
+    description: >-
+      Name of the review subagent to invoke (must match a definition in
+      .claude/agents/), e.g. pr-code-reviewer or web-security-reviewer.
+    required: true
+  oauth_token:
+    description: Claude Code OAuth token. Passed in because composite actions cannot read secrets directly.
+    required: true
+  repo:
+    description: 'owner/name of the repository under review.'
+    required: true
+  pr:
+    description: Pull request number under review.
+    required: true
+
+outputs:
+  execution_file:
+    description: Path to the Claude Code execution output for this pass.
+    value: ${{ steps.run.outputs.execution_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run Claude Code Review
+      id: run
+      uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1.0.165
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token }}
+        plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+        plugins: 'code-review@claude-code-plugins'
+        # Print the SDK output so a failed run's error is visible in the job
+        # log. The default hides it, which leaves an errored review with no
+        # diagnosable cause once the runner is gone.
+        show_full_output: true
+        prompt: |
+          Review PR ${{ inputs.repo }}#${{ inputs.pr }} by invoking the
+          `${{ inputs.reviewer }}` subagent exactly once via the Task tool,
+          synchronously (`run_in_background: false`) — a background subagent
+          dies when this CI job ends, so do not end your turn until the
+          subagent has finished and its comment is posted. The subagent is
+          defined in .claude/agents/ and must be invoked with its exact name
+          as `subagent_type`: `${{ inputs.reviewer }}`.
+
+          Pass the subagent the PR identifier `${{ inputs.repo }}#${{ inputs.pr }}`
+          and instruct it to fetch BOTH the diff (`gh pr diff <number>`) AND the
+          existing review comments (`gh pr view <number> --comments`) before
+          forming findings, so it does not re-flag items already addressed or
+          deferred in the thread. Review only the changed code, not the whole
+          codebase.
+
+          Post the review as a single PR comment using `gh pr comment`,
+          prefixed with a header identifying the reviewer: `## ${{ inputs.reviewer }}`.
+        claude_args: >-
+          --model ${{ inputs.model }}
+          --max-turns 25
+          --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
+          --append-system-prompt "You run in an ephemeral CI job that terminates the moment your turn ends. Never launch background subagents or background shell tasks — run everything synchronously (run_in_background: false) and do not end your turn while any delegated work is still pending."

--- a/.github/scripts/claude-review-ok.sh
+++ b/.github/scripts/claude-review-ok.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Decide whether a Claude review pass succeeded, from its execution output.
+#
+# Usage: claude-review-ok.sh <execution-output-file>
+# Exit 0 when the run produced a result frame with is_error == false;
+# exit 1 otherwise (missing file, no result frame, or an errored run).
+# On failure the result frame is printed so the cause is visible in the log.
+set -euo pipefail
+
+file="${1:-}"
+if [ -z "$file" ] || [ ! -f "$file" ]; then
+  echo "No execution output at '${file:-<empty>}'."
+  exit 1
+fi
+
+result=$(jq -c '[.[] | select(.type == "result")] | last' "$file")
+if [ -z "$result" ] || [ "$result" = "null" ]; then
+  echo "Execution output has no result frame."
+  exit 1
+fi
+
+is_error=$(printf '%s' "$result" | jq -r '.is_error')
+if [ "$is_error" != "false" ]; then
+  echo "Review run ended in an error (is_error=$is_error):"
+  printf '%s\n' "$result" | jq .
+  exit 1
+fi
+
+echo "Review run completed successfully."

--- a/.github/scripts/claude-review-reason.sh
+++ b/.github/scripts/claude-review-reason.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Print a short, human-readable reason a Claude review pass failed, from its
+# execution output, as markdown bullet lines. Best-effort: the precise upstream
+# error is not always in the file, so the summary always includes the
+# result-frame fields (subtype / is_error / turns / cost), which on their own
+# distinguish common cases (e.g. a usage limit shows as ~0 turns and $0 cost).
+#
+# Usage: claude-review-reason.sh <execution-output-file>
+set -euo pipefail
+
+file="${1:-}"
+if [ -z "$file" ] || [ ! -f "$file" ]; then
+  echo "- No execution output was produced (the run crashed before writing its log)."
+  exit 0
+fi
+
+result=$(jq -c '[.[] | select(.type == "result")] | last' "$file")
+if [ -z "$result" ] || [ "$result" = "null" ]; then
+  echo "- The run produced no result frame (it errored before completing a turn)."
+  exit 0
+fi
+
+printf '%s' "$result" | jq -r '
+  "- subtype: `\(.subtype // "?")`",
+  "- is_error: `\(.is_error)`",
+  "- turns: `\(.num_turns // "?")`",
+  "- cost: `$\(.total_cost_usd // 0)`"
+  + (if ((.result // .error // "") | tostring) != "" then "\n- message: \((.result // .error) | tostring)" else "" end)
+'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [ opened, synchronize, ready_for_review, reopened ]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -51,83 +51,78 @@ jobs:
           path: .claude-review-marker
           key: claude-review-pr-${{ github.event.pull_request.number }}-${{ steps.diff-hash.outputs.hash }}
 
-      - name: Run Claude Code Review
+      # Security review on Fable. continue-on-error keeps the job going even if
+      # this pass fails; whether it succeeded is decided from the execution
+      # output in the assess step below. A failed security pass is a warning,
+      # not a job failure.
+      - name: Run security review (Fable)
+        id: review-security
         if: steps.diff-cache.outputs.cache-hit != 'true'
-        id: claude-review
-        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1.0.165
+        continue-on-error: true
+        uses: ./.github/actions/claude-review
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          # Print the SDK output so a failed run's error is visible in the job
-          # log. The default hides it, which leaves an errored review with no
-          # diagnosable cause once the runner is gone.
-          show_full_output: true
-          prompt: |
-            Review PR ${{ github.repository }}#${{ github.event.pull_request.number }}
-            by delegating to TWO subagents in parallel via the Task tool. Run
-            them synchronously (`run_in_background: false`) — background
-            subagents die when this CI job ends, so do not end your turn until
-            both subagents have finished and both comments are posted. Each
-            subagent is defined in .claude/agents/ and must be invoked with its
-            exact name as `subagent_type`:
+          model: fable
+          reviewer: web-security-reviewer
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          repo: ${{ github.repository }}
+          pr: ${{ github.event.pull_request.number }}
 
-              1. pr-code-reviewer       — neutral, professional code-quality review
-              2. web-security-reviewer  — security-focused audit
+      # Code review on Opus. This is the required pass — the job fails if it
+      # does not post a review (handled in the assess step below).
+      - name: Run code review (Opus)
+        id: review-code
+        if: steps.diff-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: ./.github/actions/claude-review
+        with:
+          model: opus
+          reviewer: pr-code-reviewer
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          repo: ${{ github.repository }}
+          pr: ${{ github.event.pull_request.number }}
 
-            Pass each subagent the PR identifier
-            `${{ github.repository }}#${{ github.event.pull_request.number }}` and
-            instruct it to fetch BOTH the diff (`gh pr diff <number>`) AND the
-            existing review comments (`gh pr view <number> --comments`) before
-            forming findings, so it does not re-flag items already addressed or
-            deferred in the thread. Review only the changed code, not the whole
-            codebase.
-
-            Post the two reviews as TWO separate PR comments using
-            `gh pr comment`. Prefix each comment with a header identifying the
-            reviewer, e.g. `## pr-code-reviewer`, `## web-security-reviewer`. Do
-            not merge them into a single comment — keep each review distinct.
-          claude_args: >-
-            --model fable
-            --max-turns 25
-            --allowedTools "Read,Grep,Glob,Task,WebFetch,Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh api:*)"
-            --append-system-prompt "You run in an ephemeral CI job that terminates the moment your turn ends. Never launch background subagents or background shell tasks — run everything synchronously (run_in_background: false) and do not end your turn while any delegated work is still pending."
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
-      # The action exits 0 even when the model turn ends in an error, so an
-      # errored review would otherwise leave a green check with no review
-      # posted. Read the execution output and fail the job on an errored run,
-      # echoing the result frame so the cause is visible in the log.
-      - name: Verify the review succeeded
-        id: verify
+      # Decide success from each pass's execution output, post a PR comment for
+      # any pass that failed, and fail the job only when the required code
+      # review failed. A failed security review keeps the job green.
+      - name: Assess reviews and post failure notices
+        id: assess
         if: steps.diff-cache.outputs.cache-hit != 'true'
         env:
-          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SECURITY_FILE: ${{ steps.review-security.outputs.execution_file }}
+          CODE_FILE: ${{ steps.review-code.outputs.execution_file }}
         run: |
-          set -euo pipefail
-          if [ -z "${EXECUTION_FILE:-}" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            echo "::error::Claude review produced no execution output; treating as a failed review."
-            exit 1
-          fi
-          result=$(jq -c '[.[] | select(.type == "result")] | last' "$EXECUTION_FILE")
-          if [ -z "$result" ] || [ "$result" = "null" ]; then
-            echo "::error::Claude review output has no result frame; treating as a failed review."
-            exit 1
-          fi
-          is_error=$(printf '%s' "$result" | jq -r '.is_error')
-          if [ "$is_error" != "false" ]; then
-            echo "::error::Claude review ended in an error (is_error=$is_error); no review was posted."
-            echo "Result frame:"
-            printf '%s\n' "$result" | jq .
-            exit 1
-          fi
-          echo "Claude review completed successfully."
+          set -uo pipefail
+          code_failed=0
 
-      # Mark the diff reviewed only after a verified-successful review, so a
-      # failed run isn't cached as "done" — it will be retried on the next run
-      # of the same diff.
+          if .github/scripts/claude-review-ok.sh "$SECURITY_FILE" >/dev/null; then
+            echo "Security review (Fable) posted."
+          else
+            echo "::warning::Security review (Fable) failed; posting a notice and keeping the job green."
+            reason=$(.github/scripts/claude-review-reason.sh "$SECURITY_FILE")
+            gh pr comment "$PR" --body "$(printf '## ⚠️ Security review did not run (Fable)\n\nThe `web-security-reviewer` pass on Fable failed, so no security review was posted. This does not block the PR — the code review is unaffected.\n\n%s\n\nFull error: [run log](%s).\n' "$reason" "$RUN_URL")" \
+              || echo "::warning::Could not post the security-review failure notice."
+          fi
+
+          if .github/scripts/claude-review-ok.sh "$CODE_FILE" >/dev/null; then
+            echo "Code review (Opus) posted."
+          else
+            echo "::error::Code review (Opus) failed; posting a notice and failing the job."
+            reason=$(.github/scripts/claude-review-reason.sh "$CODE_FILE")
+            gh pr comment "$PR" --body "$(printf '## ❌ Code review did not run (Opus)\n\nThe `pr-code-reviewer` pass on Opus failed, so no code review was posted.\n\n%s\n\nFull error: [run log](%s).\n' "$reason" "$RUN_URL")" \
+              || echo "::error::Could not post the code-review failure notice."
+            code_failed=1
+          fi
+
+          exit "$code_failed"
+
+      # Mark the diff reviewed only after the required code review succeeded, so
+      # a failed run isn't cached as "done" — it will be retried on the next run
+      # of the same diff. (A best-effort security failure still caches, since
+      # the code review is the gating pass.)
       - name: Mark this diff as reviewed
-        if: steps.diff-cache.outputs.cache-hit != 'true' && steps.verify.outcome == 'success'
+        if: steps.diff-cache.outputs.cache-hit != 'true' && steps.assess.outcome == 'success'
         run: touch .claude-review-marker
 


### PR DESCRIPTION
## Summary

Reworks the review job so the two reviewers run on different models, each as an independent pass — replacing the earlier single-model-with-Opus-fallback idea.

- **`pr-code-reviewer` runs on Opus and is required.** If it posts no review, the job fails (red check).
- **`web-security-reviewer` runs on Fable with no fallback and is best-effort.** If it fails (e.g. the Fable usage limit), the job stays green.
- **Either pass failing posts a PR comment** naming the review and model, with a result-frame summary (`subtype` / `is_error` / `turns` / `cost` — which distinguishes a usage limit from other failures) and a link to the run log.

## What changed

- **Composite action** `.github/actions/claude-review` now takes a `reviewer` input and invokes that single subagent on the given `model` (the agents are `model: inherit`, so the pass's `--model` decides the subagent's model). Keeps `show_full_output: true`.
- **Helpers** in `.github/scripts/`: `claude-review-ok.sh` decides pass success from the execution output (`is_error`); `claude-review-reason.sh` formats the failure note.
- **Job flow**: run the Fable security pass and the Opus code pass (both `continue-on-error`), then an assess step posts a failure comment per failed pass and fails the job only when the required code review failed. The diff is cached as reviewed only when the code pass succeeded, so a failed code review is retried on the next run.

## Notes

- A PR touching `claude-code-review.yml` fails its own `claude-review` check by design (the review runs against the base workflow); that failure here is expected.
- Locally verified: both YAML files parse, and the helper scripts behave correctly for successful, usage-limit (`is_error`/1-turn/`$0`), missing-result-frame, and missing-file inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)