### PR TITLE
chore: unify deployable jar build between CI and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,7 @@ jobs:
         run: mvn -B test
 
       - name: build backend
-        run: mvn -B -DskipTests=true clean install
+        run: mvn -B clean package -DskipTests=true
 
-      # Exercises the same Dockerfile the release builds (semantic-release
-      # publishCmd in package.json). The jar is packaged by a different
-      # maven command there, so this validates the Dockerfile, not that build.
       - name: build Docker image
         run: docker build -t recipes:ci .

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@semantic-release/exec",
         {
           "prepareCmd": "mvn -B versions:set -DnewVersion=\"${nextRelease.version}\" -DgenerateBackupPoms=false",
-          "publishCmd": "npm run build && mvn -B clean package -DskipTests=true && docker build --tag monsieurbon/recipe:build .",
+          "publishCmd": "mvn -B clean package -DskipTests=true && docker build --tag monsieurbon/recipe:build .",
           "successCmd": "NEXT_VERSION=$(npm version $(npm version patch --no-git-tag-version)-SNAPSHOT --no-git-tag-version) && mvn -B versions:set -DnewVersion=$NEXT_VERSION -DgenerateBackupPoms=false && git commit -am \"chore(release): $NEXT_VERSION [skip ci]\" && git push"
         }
       ],


### PR DESCRIPTION
CI and the release path built the deployable jar with different commands. This consolidates them onto a single definition — `mvn -B clean package -DskipTests=true` — so CI's `docker build` genuinely exercises the artifact the release ships.

- **`build.yml`**: `clean install` → `clean package` (the local-repo copy served no purpose for a single-module build); removed the now-stale comment above the Docker step.
- **`package.json`**: dropped the redundant `npm run build` from `publishCmd`, since the frontend-maven-plugin already runs it inside the Maven lifecycle.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)