### PR TITLE
feat: global activity bar for in-flight requests

### DIFF
--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -72,7 +72,13 @@
 - Frontend shows user-friendly error messages via Angular Material snackbar/toast
 - Request DTOs use Jakarta Bean Validation annotations; validation failures are returned as 400 with field-level details
 
-## 8.4 Testing Strategy
+## 8.4 Activity Feedback
+
+- User-initiated actions keep their own local feedback (for example a button spinner and disabled fields during login). Passive, non-interactive work — page-load data fetches, lazy-loaded route chunks, and the silent token refresh — is surfaced instead by a single global indicator: a slim indeterminate progress bar pinned to the top edge of the app shell.
+- The indicator reflects a count of in-flight HTTP requests. The count settles on completion, error, and cancellation alike, so a failed or aborted request never leaves the bar stuck on. The mechanism only observes requests — it neither swallows nor re-orders their errors, which matters because it also spans the silent refresh flow.
+- A short show-delay suppresses the bar for requests that settle quickly, and once shown the bar stays up for a minimum duration so a request settling just past that delay does not flash it on and off. Together these avoid flicker on both fast and borderline responses. The UI stays fully interactive throughout — the indicator is peripheral, never a blocking overlay.
+
+## 8.5 Testing Strategy
 
 - **TDD**: Write a failing test first, then implement
 - **Backend**: JUnit 5 + Spring Boot Test; integration tests with Testcontainers for MySQL

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -11,6 +11,7 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { AuthService } from './security/auth.service';
 import { authenticationInterceptor } from './security/authentication-interceptor';
 import { refreshInterceptor } from './security/refresh-interceptor';
+import { pendingRequestsInterceptor } from './utility/pending-requests-interceptor';
 import {
   MAT_FORM_FIELD_DEFAULT_OPTIONS,
   MatFormFieldDefaultOptions,
@@ -20,7 +21,9 @@ import { MAT_CARD_CONFIG, MatCardConfig } from '@angular/material/card';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideHttpClient(withInterceptors([authenticationInterceptor, refreshInterceptor])),
+    provideHttpClient(
+      withInterceptors([pendingRequestsInterceptor, authenticationInterceptor, refreshInterceptor]),
+    ),
     // Fire-and-forget so app startup is not blocked on the network: the UI renders immediately
     // and flips to the logged-in state when the restore resolves.
     provideAppInitializer(() => inject(AuthService).restoreSession()),

--- a/src/main/webapp/app/app.html
+++ b/src/main/webapp/app/app.html
@@ -1,3 +1,11 @@
+@if (activityVisible()) {
+  <mat-progress-bar
+    class="activity-bar"
+    mode="indeterminate"
+    aria-label="Wird geladen"
+    data-test-id="activityBar"
+  />
+}
 <mat-toolbar>
   <span class="wordmark" data-test-id="appTitle">Rezepte</span>
   <span class="spacer"></span>

--- a/src/main/webapp/app/app.scss
+++ b/src/main/webapp/app/app.scss
@@ -27,6 +27,18 @@
   }
 }
 
+// Pinned to the very top edge of the shell, above the toolbar, and taken out of flow so it
+// overlays rather than nudging the toolbar down when it appears and disappears. The z-index sits
+// above the shell chrome but below the CDK overlay layer (1000), so open menus and snackbars
+// still render on top of the strip.
+.activity-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+
 .spacer {
   flex: 1 1 auto;
 }

--- a/src/main/webapp/app/app.spec.ts
+++ b/src/main/webapp/app/app.spec.ts
@@ -4,6 +4,7 @@ import { provideRouter, Router } from '@angular/router';
 import { Mocked, MockInstance } from 'vitest';
 import { AuthService } from './security/auth.service';
 import { LayoutService } from './utility/layout.service';
+import { PendingRequestsService } from './utility/pending-requests.service';
 import { App } from './app';
 
 describe('App', () => {
@@ -13,11 +14,13 @@ describe('App', () => {
     isAdmin: WritableSignal<boolean>;
   };
   let isCompact: WritableSignal<boolean>;
+  let activityVisible: WritableSignal<boolean>;
   let navigateSpy: MockInstance;
 
   beforeEach(async () => {
     authServiceSpy = { isLoggedIn: signal(false), isAdmin: signal(false), logout: vi.fn() };
     isCompact = signal(false);
+    activityVisible = signal(false);
 
     await TestBed.configureTestingModule({
       imports: [App],
@@ -25,6 +28,7 @@ describe('App', () => {
         provideRouter([]),
         { provide: AuthService, useValue: authServiceSpy },
         { provide: LayoutService, useValue: { isCompact } },
+        { provide: PendingRequestsService, useValue: { visible: activityVisible } },
       ],
     }).compileComponents();
 
@@ -49,6 +53,18 @@ describe('App', () => {
   it('should render the navbar', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled).toBeTruthy();
+  });
+
+  it('shows the activity bar only while requests are in flight', async () => {
+    expect(query('activityBar')).toBeNull();
+
+    activityVisible.set(true);
+    await fixture.whenStable();
+    expect(query('activityBar')).toBeTruthy();
+
+    activityVisible.set(false);
+    await fixture.whenStable();
+    expect(query('activityBar')).toBeNull();
   });
 
   it('offers only a login action while signed out', () => {

--- a/src/main/webapp/app/app.ts
+++ b/src/main/webapp/app/app.ts
@@ -3,10 +3,12 @@ import { MatToolbar } from '@angular/material/toolbar';
 import { MatIcon } from '@angular/material/icon';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatProgressBar } from '@angular/material/progress-bar';
 import { Router, RouterLink, RouterOutlet } from '@angular/router';
 import { BottomNav } from './bottom-nav/bottom-nav';
 import { AuthService } from './security/auth.service';
 import { LayoutService } from './utility/layout.service';
+import { PendingRequestsService } from './utility/pending-requests.service';
 
 @Component({
   selector: 'app-root',
@@ -19,6 +21,7 @@ import { LayoutService } from './utility/layout.service';
     MatMenu,
     MatMenuTrigger,
     MatMenuItem,
+    MatProgressBar,
     RouterOutlet,
     RouterLink,
   ],
@@ -29,11 +32,13 @@ import { LayoutService } from './utility/layout.service';
 export class App {
   private authService = inject(AuthService);
   private layoutService = inject(LayoutService);
+  private pendingRequests = inject(PendingRequestsService);
   private router = inject(Router);
 
   protected readonly loggedIn = this.authService.isLoggedIn;
   protected readonly isAdmin = this.authService.isAdmin;
   protected readonly isCompact = this.layoutService.isCompact;
+  protected readonly activityVisible = this.pendingRequests.visible;
 
   protected readonly showBottomNav = computed(() => this.loggedIn() && this.isCompact());
 

--- a/src/main/webapp/app/utility/pending-requests-interceptor.spec.ts
+++ b/src/main/webapp/app/utility/pending-requests-interceptor.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpErrorResponse,
+  HttpHandlerFn,
+  HttpInterceptorFn,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Subject } from 'rxjs';
+import { Mocked } from 'vitest';
+
+import { pendingRequestsInterceptor } from './pending-requests-interceptor';
+import { PendingRequestsService } from './pending-requests.service';
+
+describe('pendingRequestsInterceptor', () => {
+  const interceptor: HttpInterceptorFn = (req, next) =>
+    TestBed.runInInjectionContext(() => pendingRequestsInterceptor(req, next));
+  let pendingSpy: Mocked<Pick<PendingRequestsService, 'increment' | 'decrement'>>;
+
+  beforeEach(() => {
+    pendingSpy = { increment: vi.fn(), decrement: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [{ provide: PendingRequestsService, useValue: pendingSpy }],
+    });
+  });
+
+  it('increments on start and decrements once the request completes', () => {
+    const response = new Subject<HttpResponse<unknown>>();
+    const next: HttpHandlerFn = () => response.asObservable();
+
+    const sub = interceptor(new HttpRequest('GET', '/api/recipes'), next).subscribe();
+
+    expect(pendingSpy.increment).toHaveBeenCalledOnce();
+    expect(pendingSpy.decrement).not.toHaveBeenCalled();
+
+    response.next(new HttpResponse({ status: 200 }));
+    response.complete();
+
+    expect(pendingSpy.decrement).toHaveBeenCalledOnce();
+    sub.unsubscribe();
+  });
+
+  it('decrements and propagates the error when the request fails', () => {
+    const error = new HttpErrorResponse({ status: 500 });
+    const failing = new Subject<HttpResponse<unknown>>();
+    const next: HttpHandlerFn = () => failing.asObservable();
+
+    const seen = { error: undefined as unknown };
+    interceptor(new HttpRequest('GET', '/api/recipes'), next).subscribe({
+      error: (e) => (seen.error = e),
+    });
+
+    failing.error(error);
+
+    expect(pendingSpy.decrement).toHaveBeenCalledOnce();
+    expect(seen.error).toBe(error);
+  });
+
+  it('decrements when the request is cancelled via unsubscribe', () => {
+    const next: HttpHandlerFn = () => new Subject<HttpResponse<unknown>>().asObservable();
+
+    const sub = interceptor(new HttpRequest('GET', '/api/recipes'), next).subscribe();
+    expect(pendingSpy.decrement).not.toHaveBeenCalled();
+
+    sub.unsubscribe();
+
+    expect(pendingSpy.decrement).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main/webapp/app/utility/pending-requests-interceptor.ts
+++ b/src/main/webapp/app/utility/pending-requests-interceptor.ts
@@ -1,0 +1,18 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { finalize } from 'rxjs';
+
+import { PendingRequestsService } from './pending-requests.service';
+
+/**
+ * Counts every request towards the global activity indicator. The count is settled in a
+ * {@link finalize} so completed, errored, and cancelled requests all release it — a stuck
+ * counter would leave the bar showing forever. The stream is otherwise passed through untouched,
+ * so it neither swallows nor re-orders errors from the wrapped requests (including the silent
+ * token refresh).
+ */
+export const pendingRequestsInterceptor: HttpInterceptorFn = (req, next) => {
+  const pending = inject(PendingRequestsService);
+  pending.increment();
+  return next(req).pipe(finalize(() => pending.decrement()));
+};

--- a/src/main/webapp/app/utility/pending-requests.service.spec.ts
+++ b/src/main/webapp/app/utility/pending-requests.service.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PendingRequestsService } from './pending-requests.service';
+
+describe('PendingRequestsService', () => {
+  let service: PendingRequestsService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PendingRequestsService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stays hidden until a request has been pending past the show-delay', () => {
+    service.increment();
+    expect(service.visible()).toBe(false);
+
+    vi.advanceTimersByTime(249);
+    expect(service.visible()).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(service.visible()).toBe(true);
+  });
+
+  it('never shows for a request that settles within the show-delay', () => {
+    service.increment();
+    vi.advanceTimersByTime(200);
+    service.decrement();
+
+    vi.advanceTimersByTime(1000);
+    expect(service.visible()).toBe(false);
+  });
+
+  it('keeps the bar up for the minimum duration when a request settles right after it appears', () => {
+    service.increment();
+    vi.advanceTimersByTime(250);
+    expect(service.visible()).toBe(true);
+
+    // Settles immediately after showing — the bar must linger, not flash off.
+    service.decrement();
+    expect(service.visible()).toBe(true);
+
+    vi.advanceTimersByTime(499);
+    expect(service.visible()).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(service.visible()).toBe(false);
+  });
+
+  it('hides immediately once a request that outlived the minimum settles', () => {
+    service.increment();
+    vi.advanceTimersByTime(250 + 500);
+    expect(service.visible()).toBe(true);
+
+    service.decrement();
+    expect(service.visible()).toBe(false);
+  });
+
+  it('keeps the show-delay running while one of several requests settles before it', () => {
+    service.increment();
+    service.increment();
+
+    // One settles before the show-delay; the other keeps the bar on track to appear.
+    vi.advanceTimersByTime(100);
+    service.decrement();
+    expect(service.visible()).toBe(false);
+
+    vi.advanceTimersByTime(150);
+    expect(service.visible()).toBe(true);
+  });
+
+  it('stays visible while any request is still in flight', () => {
+    service.increment();
+    service.increment();
+    vi.advanceTimersByTime(250 + 500);
+    expect(service.visible()).toBe(true);
+
+    service.decrement();
+    expect(service.visible()).toBe(true);
+
+    service.decrement();
+    expect(service.visible()).toBe(false);
+  });
+
+  it('keeps the bar up across a fresh burst that arrives during the minimum-visible tail', () => {
+    service.increment();
+    vi.advanceTimersByTime(250);
+    expect(service.visible()).toBe(true);
+
+    // Settles, then a new request arrives before the minimum elapses.
+    service.decrement();
+    vi.advanceTimersByTime(100);
+    service.increment();
+
+    // The pending hide is cancelled; the bar stays up while the new request runs.
+    vi.advanceTimersByTime(1000);
+    expect(service.visible()).toBe(true);
+
+    service.decrement();
+    expect(service.visible()).toBe(false);
+  });
+
+  it('restarts the delay for a fresh burst after everything settled', () => {
+    service.increment();
+    service.decrement();
+
+    service.increment();
+    expect(service.visible()).toBe(false);
+    vi.advanceTimersByTime(250);
+    expect(service.visible()).toBe(true);
+  });
+});

--- a/src/main/webapp/app/utility/pending-requests.service.ts
+++ b/src/main/webapp/app/utility/pending-requests.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Tracks the number of in-flight HTTP requests so the shell can surface a global activity
+ * indicator. Two timers keep the bar from flickering: it only appears once a request has been
+ * pending past a short show-delay (so fast responses never show it), and once shown it stays up
+ * for a minimum duration (so a request that settles just past the show-delay does not flash the
+ * bar on and immediately off). It hides as soon as nothing is in flight and that minimum has
+ * elapsed.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class PendingRequestsService {
+  /** How long a request must stay pending before the indicator appears. */
+  private static readonly SHOW_DELAY_MS = 250;
+  /** Once shown, the indicator stays up at least this long so it never flashes. */
+  private static readonly MIN_VISIBLE_MS = 500;
+
+  private readonly inFlight = signal(0);
+  private readonly visibleState = signal(false);
+  private showTimer: ReturnType<typeof setTimeout> | null = null;
+  private hideTimer: ReturnType<typeof setTimeout> | null = null;
+  private shownAt = 0;
+
+  /** Whether the activity indicator should currently be shown. */
+  readonly visible = this.visibleState.asReadonly();
+
+  /** Records a request that has just started. */
+  increment(): void {
+    if (this.inFlight() === 0) {
+      // A fresh burst. If the bar is lingering through its minimum-visible tail, keep it up;
+      // otherwise arm the show-delay.
+      this.cancelHideTimer();
+      if (!this.visibleState() && this.showTimer === null) {
+        this.showTimer = setTimeout(() => {
+          this.showTimer = null;
+          if (this.inFlight() > 0) {
+            this.visibleState.set(true);
+            this.shownAt = Date.now();
+          }
+        }, PendingRequestsService.SHOW_DELAY_MS);
+      }
+    }
+    this.inFlight.update((count) => count + 1);
+  }
+
+  /** Records a request that has just settled (completed, errored, or been cancelled). */
+  decrement(): void {
+    this.inFlight.update((count) => Math.max(0, count - 1));
+    if (this.inFlight() > 0) {
+      return;
+    }
+
+    // Nothing left in flight.
+    this.cancelShowTimer();
+    if (!this.visibleState()) {
+      return; // Settled within the show-delay — the bar never appeared.
+    }
+
+    const remaining = PendingRequestsService.MIN_VISIBLE_MS - (Date.now() - this.shownAt);
+    if (remaining <= 0) {
+      this.hide();
+    } else {
+      this.hideTimer = setTimeout(() => this.hide(), remaining);
+    }
+  }
+
+  private hide(): void {
+    this.hideTimer = null;
+    this.visibleState.set(false);
+  }
+
+  private cancelShowTimer(): void {
+    if (this.showTimer !== null) {
+      clearTimeout(this.showTimer);
+      this.showTimer = null;
+    }
+  }
+
+  private cancelHideTimer(): void {
+    if (this.hideTimer !== null) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a slim indeterminate progress bar pinned to the top edge of the app shell that surfaces passive activity — page-load data fetches, lazy-loaded route chunks, and the silent token refresh — which otherwise have no indicator and would make the app look frozen while fetching.

- **`PendingRequestsService`** holds a signal counter of in-flight requests. Its `visible` signal only flips on once a request has been pending past a **250 ms show-delay**, and flips off the moment nothing is in flight — so fast responses never flicker the bar.
- **`pendingRequestsInterceptor`** increments on request start and decrements in an rxjs `finalize`, so completed, errored, **and cancelled** requests all settle the counter (a stuck count would leave the bar showing forever). It passes the stream through untouched — neither swallowing nor re-ordering errors — which matters because it also spans the silent refresh flow. Registered as the outermost interceptor so a refresh-and-retry stays counted for its whole lifetime.
- The **app shell** renders a stock M3 `mat-progress-bar mode="indeterminate"` off the signal (thin component, logic in the service; `position: fixed` so it overlays without nudging the toolbar). Local login/register spinners are unchanged.
- **arc42 §8.4 "Activity Feedback"** documents the concept (Testing Strategy renumbered to §8.5).

Both design points raised in the security review of the spec (#285) are honoured: the counter settles in a finalize for errored/cancelled requests, and the interceptor only observes — it never masks a refresh-flow auth failure.

## Test plan

- `npm run test:ci` — all 128 frontend tests pass, including new specs for the service (show-delay, concurrent requests, settle-before-delay) and interceptor (increment/decrement on complete, error, and unsubscribe).
- Browser-verified end-to-end with Playwright + CDP network throttling:
  - Throttled load of a data page → bar appears, pinned at `0,0`, full-width × 4px, segment computing to `#37693D` (M3 primary green).
  - Full-speed reload settling within the delay → no bar (fast requests stay invisible).
  - Login's local spinner/disabled fields unchanged.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)