### PR TITLE
Global handling for unexpected frontend errors

### DIFF
--- a/docs/arc42/08-crosscutting-concepts.md
+++ b/docs/arc42/08-crosscutting-concepts.md
@@ -68,9 +68,11 @@
 
 ## 8.3 Error Handling
 
-- Backend returns structured JSON error responses with appropriate HTTP status codes
-- Frontend shows user-friendly error messages via Angular Material snackbar/toast
-- Request DTOs use Jakarta Bean Validation annotations; validation failures are returned as 400 with field-level details
+- Backend returns structured JSON error responses with appropriate HTTP status codes. Request payloads use bean validation; validation failures are returned as 400 with field-level details.
+- The frontend follows one rule — **catch only what you can act on; let everything else bubble to a single global handler** — which yields two layers:
+  - **Contextual, actionable errors stay where they happen.** Failures the user can act on — wrong credentials on login, an already-taken username or email on registration, field validation — are caught and shown inline by the form that made the request. Because they are caught, they never reach the global layer.
+  - **A single global handler catches everything else.** Anything that no one caught — an uncaught runtime error, a template failure, or an HTTP failure (5xx, network outage, or a status a form failed to handle) — is logged and surfaces one shared, transient, generic notification. Each unhandled error therefore produces exactly one notification. The message is deliberately generic and never includes the error's own text or response body — details are logged only.
+- Components and services deliberately narrow their own `catch`/error handling to the cases they can resolve and let the rest propagate, so a genuine failure is never silently swallowed. The passive startup session-restore is the one background caller: it treats "no session" as its normal outcome (stay anonymous, silently) but routes an unexpected transport/server failure to the same global handler.
 
 ## 8.4 Activity Feedback
 

--- a/src/main/webapp/_layout.scss
+++ b/src/main/webapp/_layout.scss
@@ -1,0 +1,5 @@
+// Total footprint of the fixed bottom navigation on compact layouts. Anything that must clear the
+// bar — the page content's bottom padding, the error-notification offset — reserves this much space
+// at the bottom edge. Kept here as a single source so those offsets can never drift out of lockstep
+// with the bar's height.
+$bottom-nav-height: 72px;

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationConfig,
+  ErrorHandler,
   inject,
   provideAppInitializer,
   provideBrowserGlobalErrorListeners,
@@ -11,6 +12,7 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { AuthService } from './security/auth.service';
 import { authenticationInterceptor } from './security/authentication-interceptor';
 import { refreshInterceptor } from './security/refresh-interceptor';
+import { GlobalErrorHandler } from './utility/global-error-handler';
 import { pendingRequestsInterceptor } from './utility/pending-requests-interceptor';
 import {
   MAT_FORM_FIELD_DEFAULT_OPTIONS,
@@ -21,6 +23,7 @@ import { MAT_CARD_CONFIG, MatCardConfig } from '@angular/material/card';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    { provide: ErrorHandler, useClass: GlobalErrorHandler },
     provideHttpClient(
       withInterceptors([pendingRequestsInterceptor, authenticationInterceptor, refreshInterceptor]),
     ),

--- a/src/main/webapp/app/app.scss
+++ b/src/main/webapp/app/app.scss
@@ -1,3 +1,5 @@
+@use '../layout' as layout;
+
 .wordmark {
   font: var(--mat-sys-title-large);
   font-weight: 600;
@@ -23,7 +25,7 @@
 
   // Keep the page's end reachable behind the fixed bottom nav.
   &.has-bottom-nav {
-    padding-bottom: calc(72px + env(safe-area-inset-bottom));
+    padding-bottom: calc(#{layout.$bottom-nav-height} + env(safe-area-inset-bottom));
   }
 }
 

--- a/src/main/webapp/app/security/auth.service.spec.ts
+++ b/src/main/webapp/app/security/auth.service.spec.ts
@@ -1,19 +1,27 @@
 import { TestBed } from '@angular/core/testing';
+import { ErrorHandler } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { firstValueFrom } from 'rxjs';
+import { Mock } from 'vitest';
 
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
   let httpMock: HttpTestingController;
+  let errorHandler: { handleError: Mock };
 
   beforeEach(() => {
     localStorage.clear();
+    errorHandler = { handleError: vi.fn() };
 
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ErrorHandler, useValue: errorHandler },
+      ],
     });
 
     service = TestBed.inject(AuthService);
@@ -233,7 +241,7 @@ describe('AuthService', () => {
     expect(service.getAccessToken()).toBe('restored');
   });
 
-  it('restoreSession leaves the user anonymous when no session exists', () => {
+  it('restoreSession leaves the user anonymous — and stays silent — when no session exists', () => {
     service.restoreSession();
 
     httpMock
@@ -242,6 +250,21 @@ describe('AuthService', () => {
 
     expect(service.isLoggedIn()).toBe(false);
     expect(service.getAccessToken()).toBeNull();
+    // A missing session is the expected outcome, not an error to notify about.
+    expect(errorHandler.handleError).not.toHaveBeenCalled();
+  });
+
+  it('restoreSession reports an unexpected failure so the user is notified, staying anonymous', async () => {
+    service.restoreSession();
+    const settled = service.whenSessionRestored();
+
+    httpMock
+      .expectOne('/api/auth/refresh')
+      .flush(null, { status: 500, statusText: 'Server Error' });
+    await settled;
+
+    expect(errorHandler.handleError).toHaveBeenCalledOnce();
+    expect(service.isLoggedIn()).toBe(false);
   });
 
   it('restoreSession does not resurrect a session ended by an explicit logout', () => {

--- a/src/main/webapp/app/security/auth.service.ts
+++ b/src/main/webapp/app/security/auth.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { computed, inject, Injectable, signal } from '@angular/core';
+import { computed, ErrorHandler, inject, Injectable, signal } from '@angular/core';
 import {
   catchError,
   finalize,
@@ -40,6 +40,18 @@ export interface CurrentUser {
   email: string;
 }
 
+/**
+ * Signals that a refresh was deliberately aborted because the user had explicitly logged out, as
+ * opposed to a transport or server failure. Its own type lets the startup restore tell this
+ * expected "stay anonymous" outcome apart from an unexpected error worth notifying about.
+ */
+class SessionEndedError extends Error {
+  constructor() {
+    super('Session was ended by an explicit logout');
+    this.name = 'SessionEndedError';
+  }
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -51,6 +63,7 @@ export class AuthService {
   // it. Set only on user-initiated logout, never by automatic session cleanup.
   private static readonly LOGGED_OUT_KEY = 'loggedOut';
 
+  private errorHandler = inject(ErrorHandler);
   private http = inject(HttpClient);
   private localStorage = inject(LocalStorage);
 
@@ -136,15 +149,29 @@ export class AuthService {
   }
 
   // Called once at startup: the refresh cookie is HttpOnly and invisible to JS, so attempting a
-  // refresh is the only way to learn whether a session survived the reload. Failure is swallowed
-  // and the user simply stays anonymous — typically a 401 because there is no session, or the
-  // logged-out marker blocking the refresh after an explicit logout.
+  // refresh is the only way to learn whether a session survived the reload. An expected failure —
+  // a 401 because there is no session, or the logged-out marker blocking the refresh after an
+  // explicit logout — leaves the user anonymous silently. An unexpected one (server error, network
+  // outage) is handed to the global ErrorHandler so the user gets the generic notification, but the
+  // restore still settles as anonymous so route guards awaiting it are never left hanging.
   restoreSession(): void {
     this.sessionRestored = firstValueFrom(
       this.refresh().pipe(
         map(() => undefined),
-        catchError(() => of(undefined)),
+        catchError((error: unknown) => {
+          if (!AuthService.isExpectedRestoreFailure(error)) {
+            this.errorHandler.handleError(error);
+          }
+          return of(undefined);
+        }),
       ),
+    );
+  }
+
+  private static isExpectedRestoreFailure(error: unknown): boolean {
+    return (
+      error instanceof SessionEndedError ||
+      (error instanceof HttpErrorResponse && error.status === 401)
     );
   }
 
@@ -165,7 +192,7 @@ export class AuthService {
 
   refresh(): Observable<string> {
     if (this.localStorage.getItem(AuthService.LOGGED_OUT_KEY)) {
-      return throwError(() => AuthService.loggedOutError());
+      return throwError(() => new SessionEndedError());
     }
     // The refresh token rides along as an HttpOnly cookie; withCredentials lets the browser send it.
     this.refreshInFlight$ ??= this.http
@@ -177,7 +204,7 @@ export class AuthService {
         // handed to callers such as the interceptor's retry.
         map((response) => {
           if (this.localStorage.getItem(AuthService.LOGGED_OUT_KEY)) {
-            throw AuthService.loggedOutError();
+            throw new SessionEndedError();
           }
           return response;
         }),
@@ -191,10 +218,6 @@ export class AuthService {
         shareReplay(1),
       );
     return this.refreshInFlight$;
-  }
-
-  private static loggedOutError(): Error {
-    return new Error('Session was ended by an explicit logout');
   }
 
   // Local session state is dropped up front regardless of the backend result — the user asked to

--- a/src/main/webapp/app/security/refresh-interceptor.spec.ts
+++ b/src/main/webapp/app/security/refresh-interceptor.spec.ts
@@ -7,12 +7,34 @@ import {
   HttpRequest,
   HttpResponse,
 } from '@angular/common/http';
-import { firstValueFrom, of, throwError } from 'rxjs';
+import { firstValueFrom, Observable, of, throwError } from 'rxjs';
 import { Mocked } from 'vitest';
 import { Router } from '@angular/router';
 
 import { refreshInterceptor } from './refresh-interceptor';
 import { AuthService } from './auth.service';
+
+// Observes a stream to its end without rejecting on completion, so a "completes silently" outcome
+// (which firstValueFrom would turn into an EmptyError) can be asserted directly.
+async function settle(
+  source: Observable<unknown>,
+): Promise<{ error: unknown; emitted: boolean; completed: boolean }> {
+  const seen = { error: undefined as unknown, emitted: false, completed: false };
+  await new Promise<void>((resolve) => {
+    source.subscribe({
+      next: () => (seen.emitted = true),
+      error: (e) => {
+        seen.error = e;
+        resolve();
+      },
+      complete: () => {
+        seen.completed = true;
+        resolve();
+      },
+    });
+  });
+  return seen;
+}
 
 describe('refreshInterceptor', () => {
   const interceptor: HttpInterceptorFn = (req, next) =>
@@ -72,27 +94,47 @@ describe('refreshInterceptor', () => {
     expect((result as HttpResponse<unknown>).status).toBe(200);
   });
 
-  it('drops the local session, routes to login, and propagates the error when the refresh itself fails', async () => {
+  it('drops the local session, routes to login, and completes silently when the refresh itself fails', async () => {
+    // logoutToLogin's redirect is the whole response — including a deliberate cross-tab logout — so
+    // the aborted request must complete without an error the global handler would toast.
     authServiceSpy.refresh.mockReturnValue(throwError(() => new Error('refresh failed')));
     const next: HttpHandlerFn = () => throwError(() => new HttpErrorResponse({ status: 401 }));
 
-    await expect(
-      firstValueFrom(interceptor(new HttpRequest('GET', '/api/recipes'), next)),
-    ).rejects.toBeTruthy();
+    const seen = await settle(interceptor(new HttpRequest('GET', '/api/recipes'), next));
+
+    expect(seen.error).toBeUndefined();
+    expect(seen.emitted).toBe(false);
+    expect(seen.completed).toBe(true);
     expect(authServiceSpy.clearLocalSession).toHaveBeenCalledOnce();
     expect(routerSpy.navigate).toHaveBeenCalledExactlyOnceWith(['login']);
   });
 
-  it('drops the local session and routes to login when the retried request also returns 401', async () => {
+  it('drops the local session, routes to login, and completes silently when the retried request also returns 401', async () => {
     authServiceSpy.refresh.mockReturnValue(of('new-access'));
     // next always rejects with 401, including the retry.
     const next: HttpHandlerFn = () => throwError(() => new HttpErrorResponse({ status: 401 }));
 
-    await expect(
-      firstValueFrom(interceptor(new HttpRequest('GET', '/api/recipes'), next)),
-    ).rejects.toBeTruthy();
+    const seen = await settle(interceptor(new HttpRequest('GET', '/api/recipes'), next));
+
+    expect(seen.error).toBeUndefined();
+    expect(seen.completed).toBe(true);
     expect(authServiceSpy.clearLocalSession).toHaveBeenCalledOnce();
     expect(routerSpy.navigate).toHaveBeenCalledExactlyOnceWith(['login']);
+  });
+
+  it('propagates a non-401 failure of the retried request instead of swallowing it', async () => {
+    authServiceSpy.refresh.mockReturnValue(of('new-access'));
+    const next: HttpHandlerFn = (r) =>
+      throwError(() =>
+        r.headers.get('Authorization') === 'Bearer new-access'
+          ? new HttpErrorResponse({ status: 500 })
+          : new HttpErrorResponse({ status: 401 }),
+      );
+
+    await expect(
+      firstValueFrom(interceptor(new HttpRequest('GET', '/api/recipes'), next)),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
   });
 
   it('does not attempt a refresh for auth endpoints', async () => {

--- a/src/main/webapp/app/security/refresh-interceptor.ts
+++ b/src/main/webapp/app/security/refresh-interceptor.ts
@@ -1,12 +1,19 @@
 import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { catchError, switchMap, throwError } from 'rxjs';
+import { catchError, EMPTY, switchMap, throwError } from 'rxjs';
 import { AuthService } from './auth.service';
 
 // On a 401 for a protected request, obtain a usable access token and retry the request once. Auth
 // endpoints are excluded so a failed login/refresh is not retried. A failed refresh, or a retry
 // that still 401s, logs the user out and routes to the login page.
+//
+// Contract: when the session cannot be renewed, the redirect to login is the whole outcome, so the
+// request's stream COMPLETES WITHOUT EMITTING rather than erroring — an errored abort would reach
+// the global handler and toast on a plain logout. Consume protected requests accordingly: read them
+// via `toSignal`/`subscribe`, or if a promise is needed pass a `defaultValue` to `firstValueFrom`.
+// A bare `firstValueFrom`/`lastValueFrom` rejects an empty completion with `EmptyError`, which would
+// itself surface the generic error notification.
 //
 // Two paths avoid redundant refreshes when several requests 401 around the same time:
 //  - if a concurrent refresh already minted a newer token while this request was in flight (the
@@ -39,8 +46,12 @@ export const refreshInterceptor: HttpInterceptorFn = (req, next) => {
           req.clone({ headers: req.headers.set('Authorization', `Bearer ${accessToken}`) }),
         ).pipe(
           catchError((retryError: unknown) => {
+            // A retry that still 401s means the session is truly gone: logoutToLogin handles it by
+            // redirecting to login, so complete silently. Any other failure is the real request
+            // failing — let it surface.
             if (isUnauthorized(retryError)) {
               logoutToLogin();
+              return EMPTY;
             }
             return throwError(() => retryError);
           }),
@@ -52,9 +63,12 @@ export const refreshInterceptor: HttpInterceptorFn = (req, next) => {
       }
 
       return authService.refresh().pipe(
-        catchError((refreshError: unknown) => {
+        // Any failure to renew the session — it expired, was revoked, or the user logged out — is
+        // handled by logoutToLogin redirecting to login, so complete silently rather than surfacing
+        // it as an error the global handler would toast.
+        catchError(() => {
           logoutToLogin();
-          return throwError(() => refreshError);
+          return EMPTY;
         }),
         switchMap(retryWith),
       );

--- a/src/main/webapp/app/utility/error-notification/error-notification.html
+++ b/src/main/webapp/app/utility/error-notification/error-notification.html
@@ -1,0 +1,4 @@
+<span matSnackBarLabel>{{ data.message }}</span>
+<button matIconButton matSnackBarAction aria-label="Schliessen" (click)="dismiss()">
+  <mat-icon>close</mat-icon>
+</button>

--- a/src/main/webapp/app/utility/error-notification/error-notification.scss
+++ b/src/main/webapp/app/utility/error-notification/error-notification.scss
@@ -1,0 +1,20 @@
+// Message and ✕ share one row (matching the design mockup): the label takes the free space and
+// the dismiss button stays at its intrinsic size on the right. Laid out here rather than via the
+// MatSnackBar actions wrapper, whose stacked layout would push the ✕ onto its own line.
+:host {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+[matSnackBarLabel] {
+  flex: 1;
+}
+
+// A text-button action would inherit the inverse-primary tint automatically; an icon button does
+// not, so restore it explicitly to keep the ✕ on-brand against the inverse surface.
+[matSnackBarAction] {
+  flex: none;
+  margin-right: -0.5rem;
+  color: var(--mat-sys-inverse-primary);
+}

--- a/src/main/webapp/app/utility/error-notification/error-notification.spec.ts
+++ b/src/main/webapp/app/utility/error-notification/error-notification.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material/snack-bar';
+import { Mock } from 'vitest';
+
+import { ErrorNotification } from './error-notification';
+
+describe('ErrorNotification', () => {
+  let dismiss: Mock;
+
+  function createComponent(message = 'Etwas ist schiefgelaufen. Bitte versuche es erneut.') {
+    dismiss = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MatSnackBarRef, useValue: { dismiss } },
+        { provide: MAT_SNACK_BAR_DATA, useValue: { message } },
+      ],
+    });
+    const fixture = TestBed.createComponent(ErrorNotification);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders the message from the injected data via text binding', () => {
+    const fixture = createComponent('Boom');
+
+    expect(fixture.nativeElement.textContent).toContain('Boom');
+  });
+
+  it('labels the close button so screen readers announce it', () => {
+    const fixture = createComponent();
+
+    const closeButton: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    expect(closeButton.getAttribute('aria-label')).toBe('Schliessen');
+  });
+
+  it('dismisses the snackbar when the close button is clicked', () => {
+    const fixture = createComponent();
+
+    fixture.nativeElement.querySelector('button').click();
+
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main/webapp/app/utility/error-notification/error-notification.ts
+++ b/src/main/webapp/app/utility/error-notification/error-notification.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import {
+  MAT_SNACK_BAR_DATA,
+  MatSnackBarAction,
+  MatSnackBarLabel,
+  MatSnackBarRef,
+} from '@angular/material/snack-bar';
+
+/** Payload the {@link NotificationService} hands to the snackbar content component. */
+export interface ErrorNotificationData {
+  message: string;
+}
+
+/**
+ * Content component for the shared error snackbar. The string-based {@code MatSnackBar} API only
+ * renders a text action, so the ✕ dismiss control needs a custom component. The message is bound
+ * as plain text (never {@code innerHTML}) so nothing from an error can be interpolated as markup.
+ */
+@Component({
+  selector: 'app-error-notification',
+  imports: [MatSnackBarLabel, MatSnackBarAction, MatIconButton, MatIcon],
+  templateUrl: './error-notification.html',
+  styleUrl: './error-notification.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ErrorNotification {
+  private readonly snackBarRef = inject(MatSnackBarRef);
+
+  readonly data = inject<ErrorNotificationData>(MAT_SNACK_BAR_DATA);
+
+  dismiss(): void {
+    this.snackBarRef.dismiss();
+  }
+}

--- a/src/main/webapp/app/utility/global-error-handler.spec.ts
+++ b/src/main/webapp/app/utility/global-error-handler.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Mocked } from 'vitest';
+
+import { GlobalErrorHandler } from './global-error-handler';
+import { NotificationService } from './notification.service';
+
+describe('GlobalErrorHandler', () => {
+  let notification: Mocked<Pick<NotificationService, 'showGenericError'>>;
+  let handler: GlobalErrorHandler;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    notification = { showGenericError: vi.fn() };
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    TestBed.configureTestingModule({
+      providers: [GlobalErrorHandler, { provide: NotificationService, useValue: notification }],
+    });
+    handler = TestBed.inject(GlobalErrorHandler);
+  });
+
+  afterEach(() => consoleError.mockRestore());
+
+  it('logs and notifies for a non-HTTP error', () => {
+    const error = new Error('boom');
+
+    handler.handleError(error);
+
+    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(notification.showGenericError).toHaveBeenCalledOnce();
+  });
+
+  it('logs and notifies for an HttpErrorResponse too — reaching here means no one handled it', () => {
+    const error = new HttpErrorResponse({ status: 500 });
+
+    handler.handleError(error);
+
+    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(notification.showGenericError).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main/webapp/app/utility/global-error-handler.ts
+++ b/src/main/webapp/app/utility/global-error-handler.ts
@@ -1,0 +1,23 @@
+import { ErrorHandler, inject, Injectable, Injector } from '@angular/core';
+
+import { NotificationService } from './notification.service';
+
+/**
+ * The application's single error notifier and catch-all. Anything reaching here — an uncaught
+ * runtime error, a template failure, or an HTTP failure that no local handler caught — is by
+ * definition unhandled, so it is logged and surfaces the one generic notification. Errors the user
+ * can act on never arrive here: the forms catch their own contextual statuses (invalid credentials,
+ * duplicate username) before they can bubble. The natural extension point for error reporting later.
+ */
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+  // Resolved lazily: this handler is instantiated very early in bootstrap, and pulling in the
+  // snackbar stack (and its overlay dependencies) eagerly at that point risks a cyclic/premature
+  // instantiation. The injector defers that to the first error.
+  private readonly injector = inject(Injector);
+
+  handleError(error: unknown): void {
+    console.error(error);
+    this.injector.get(NotificationService).showGenericError();
+  }
+}

--- a/src/main/webapp/app/utility/notification.service.spec.ts
+++ b/src/main/webapp/app/utility/notification.service.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
+import { Mock } from 'vitest';
+
+import { AuthService } from '../security/auth.service';
+import { ErrorNotification } from './error-notification/error-notification';
+import { LayoutService } from './layout.service';
+import { NotificationService } from './notification.service';
+
+describe('NotificationService', () => {
+  let snackBar: { openFromComponent: Mock };
+  const isCompact = signal(false);
+  const isLoggedIn = signal(true);
+
+  function createService(): NotificationService {
+    snackBar = { openFromComponent: vi.fn() };
+    isCompact.set(false);
+    isLoggedIn.set(true);
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MatSnackBar, useValue: snackBar },
+        { provide: LayoutService, useValue: { isCompact } },
+        { provide: AuthService, useValue: { isLoggedIn } },
+      ],
+    });
+    return TestBed.inject(NotificationService);
+  }
+
+  function lastConfig(): MatSnackBarConfig {
+    return snackBar.openFromComponent.mock.calls[0][1] as MatSnackBarConfig;
+  }
+
+  it('opens the error content component with the fixed generic German message', () => {
+    createService().showGenericError();
+
+    expect(snackBar.openFromComponent).toHaveBeenCalledOnce();
+    expect(snackBar.openFromComponent.mock.calls[0][0]).toBe(ErrorNotification);
+    expect(lastConfig().data).toEqual({
+      message: 'Etwas ist schiefgelaufen. Bitte versuche es erneut.',
+    });
+  });
+
+  it('auto-dismisses after about six seconds', () => {
+    createService().showGenericError();
+
+    expect(lastConfig().duration).toBe(6000);
+  });
+
+  it('does not offset the snackbar on non-compact layouts', () => {
+    createService().showGenericError();
+
+    expect(lastConfig().panelClass).toEqual([]);
+  });
+
+  it('lifts the snackbar above the bottom nav when compact and logged in', () => {
+    const service = createService();
+    isCompact.set(true);
+    isLoggedIn.set(true);
+
+    service.showGenericError();
+
+    expect(lastConfig().panelClass).toEqual(['notification-above-bottom-nav']);
+  });
+
+  it('does not offset the snackbar when compact but logged out (no bottom nav)', () => {
+    const service = createService();
+    isCompact.set(true);
+    isLoggedIn.set(false);
+
+    service.showGenericError();
+
+    expect(lastConfig().panelClass).toEqual([]);
+  });
+});

--- a/src/main/webapp/app/utility/notification.service.ts
+++ b/src/main/webapp/app/utility/notification.service.ts
@@ -1,0 +1,41 @@
+import { inject, Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+import { AuthService } from '../security/auth.service';
+import { ErrorNotification, ErrorNotificationData } from './error-notification/error-notification';
+import { LayoutService } from './layout.service';
+
+/**
+ * Central producer of the app's shared error notification. The global {@code ErrorHandler} routes
+ * through here so there is a single owner of the message text, timing, and placement — the message
+ * is fixed and generic on purpose, so an error's own text is never surfaced to the user.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class NotificationService {
+  // German to match the rest of the UI. Kept deliberately generic: never interpolate an error's
+  // message, response body, or stack — those belong in the console/log only.
+  private static readonly GENERIC_ERROR_MESSAGE =
+    'Etwas ist schiefgelaufen. Bitte versuche es erneut.';
+
+  // Auto-dismiss window; a ✕ in the content component closes it sooner. MatSnackBar shows one
+  // notice at a time and replaces the visible one when a newer error arrives, so they never stack.
+  private static readonly DURATION_MS = 6000;
+
+  private readonly auth = inject(AuthService);
+  private readonly layout = inject(LayoutService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  /** Surfaces the one generic notification for any error the user cannot act on. */
+  showGenericError(): void {
+    // The fixed bottom navigation — shown only to a signed-in user on a phone — owns the bottom
+    // edge, so lift the toast clear of it exactly when that nav is present.
+    const aboveBottomNav = this.layout.isCompact() && this.auth.isLoggedIn();
+    this.snackBar.openFromComponent(ErrorNotification, {
+      data: { message: NotificationService.GENERIC_ERROR_MESSAGE } satisfies ErrorNotificationData,
+      duration: NotificationService.DURATION_MS,
+      panelClass: aboveBottomNav ? ['notification-above-bottom-nav'] : [],
+    });
+  }
+}

--- a/src/main/webapp/styles.scss
+++ b/src/main/webapp/styles.scss
@@ -1,4 +1,5 @@
 @use '@angular/material' as mat;
+@use 'layout' as layout;
 @use 'assets/icons/material-icons';
 @use 'assets/fonts/roboto';
 @use 'assets/fonts/fraunces';
@@ -41,4 +42,12 @@ h2 {
       )
     );
   }
+}
+
+// The error snackbar renders in the CDK overlay at document level, so its compact offset lives
+// here rather than in a component's styles. On phones the fixed bottom navigation owns the bottom
+// edge; lift the toast clear of it so the two never overlap. The container selector is repeated to
+// win over Material's default container margin on specificity.
+.mat-mdc-snack-bar-container.notification-above-bottom-nav {
+  margin-bottom: calc(#{layout.$bottom-nav-height} + env(safe-area-inset-bottom));
 }


### PR DESCRIPTION
## Summary

Unexpected frontend errors previously vanished — a 5xx or network outage on a backend request rejected out of the caller with no user feedback. This adds global error handling built on one rule: **catch only what you can act on; let everything else bubble to a single global handler.**

- **Contextual errors stay inline.** Forms catch their own actionable statuses — invalid credentials (401) on login, a taken username/email (409) on registration, field validation — and show them in place. Because they're caught, they never reach the global layer.
- **One global `ErrorHandler` handles the rest.** Anything nobody caught — an uncaught runtime error, a template failure, or an HTTP failure — is logged and surfaces a single shared, transient, generic snackbar («Etwas ist schiefgelaufen. Bitte versuche es erneut.»). Each unhandled error yields exactly one log + one notification. The message is fixed and generic; error text, response bodies, and stacks are never interpolated into the UI (logged only).
- **Callers narrow their own error handling** to what they can resolve. The passive startup session-restore stays anonymous silently on the expected "no session" outcome but routes an unexpected 5xx/network to the handler. The refresh interceptor treats a redirect-to-login as the handling and completes aborted requests silently rather than surfacing a spurious error.

The snackbar is a stock M3 inverse-surface notice with a ✕ dismiss (`aria-label="Schliessen"`), offset above the bottom nav on compact.

arc42 §8.3 documents the two-layer model.

## Test plan

- Frontend unit tests (global handler, notification service + content component, auth restore split, refresh-interceptor silent-completion paths); lint + Prettier.
- Browser-verified via Playwright:
  - Login 500 → exactly one generic toast; ✕ dismisses it
  - Login 401 (bad creds) → inline error, no toast
  - Startup restore 5xx → toast; startup restore 401 (no session) → silent
  - Login/logout happy path → no errant toast

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)